### PR TITLE
Always close closeable

### DIFF
--- a/recipes/Java/Basic/Always_close_closeable_at_end_of_scope.yaml
+++ b/recipes/Java/Basic/Always_close_closeable_at_end_of_scope.yaml
@@ -15,7 +15,7 @@ search:
           name: close
     type: java.io.Closeable
 availableFixes:
-- name: empty fix
+- name: Close the resource after its last use
   actions:
   - addMethodCall:
       name: close

--- a/recipes/Java/Basic/Always_close_closeable_at_end_of_scope.yaml
+++ b/recipes/Java/Basic/Always_close_closeable_at_end_of_scope.yaml
@@ -1,7 +1,7 @@
 id: scw:java:unreleased-streams
 version: 8
 metadata:
-  name: 'Unreleased Resource: Streams: Always close stream at end of scope'
+  name: 'Unreleased Resource: Always close stream at end of scope'
   shortDescription: Resource has not been closed
   level: error
   language: java
@@ -13,7 +13,7 @@ search:
       followedBy:
         methodcall:
           name: close
-    type: java.io.BufferedReader
+    type: java.io.Closeable
 availableFixes:
 - name: empty fix
   actions:


### PR DESCRIPTION
- Changed from java.io.BufferedReader to the more general java.io.Closeable
- Renamed to Always_close_closeable as streams in Java often refers to the stream API
- With the above point in mind I moved it into the root Basic directory, initially I thought about an IO directory but Closeable isn't only  applicable in IO context
