### PR TITLE
SEN-2228: Spring Security: use mvcMatchers instead of antMatchers

### DIFF
--- a/recipes/Java/Spring/Security/Access_Control_Use_MvcMatchers_Instead_of_AntMatchers.yaml
+++ b/recipes/Java/Spring/Security/Access_Control_Use_MvcMatchers_Instead_of_AntMatchers.yaml
@@ -1,4 +1,4 @@
-id: New_Recipe
+id: scw:spring:access-control-use-mvcMatchers-over-antMatchers
 version: 8
 metadata:
   name: 'Access Control: MvcRequestMatcher is more secure than AntPathRequestMatcher
@@ -11,6 +11,7 @@ metadata:
   scwCategory: access:functionlevel
   enabled: true
   descriptionFile: Java/Spring/Security/descriptions/Access_Control__MvcRequestMatcher_is_more_secure_than_AntPathRequestMatcher_for_Spring_MVC_patterns.html
+  tags: spring;security;spring-mvc;spring-security;access-control
 search:
   methodcall:
     name: antMatchers

--- a/recipes/Java/Spring/Security/Access_Control_Use_MvcMatchers_Instead_of_AntMatchers.yaml
+++ b/recipes/Java/Spring/Security/Access_Control_Use_MvcMatchers_Instead_of_AntMatchers.yaml
@@ -1,0 +1,23 @@
+id: New_Recipe
+version: 8
+metadata:
+  name: 'Access Control: MvcRequestMatcher is more secure than AntPathRequestMatcher
+    for Spring MVC patterns'
+  shortDescription: When using Spring MVC it's recommended to use MvcRequestMatcher
+    as it protects the paths Spring annotations will match on, instead of only the
+    one provided.
+  level: warning
+  language: java
+  scwCategory: access:functionlevel
+  enabled: true
+  descriptionFile: Java/Spring/Security/descriptions/Access_Control__MvcRequestMatcher_is_more_secure_than_AntPathRequestMatcher_for_Spring_MVC_patterns.html
+search:
+  methodcall:
+    name: antMatchers
+    declaration:
+      type: org.springframework.security.config.annotation.web.AbstractRequestMatcherRegistry
+availableFixes:
+- name: Use MvcRequestMatchers
+  actions:
+  - rewrite:
+      to: '{{{ qualifier }}}.mvcMatchers({{{ arguments.0 }}})'

--- a/recipes/Java/Spring/Security/Access_Control_Use_MvcMatchers_Instead_of_AntMatchers.yaml
+++ b/recipes/Java/Spring/Security/Access_Control_Use_MvcMatchers_Instead_of_AntMatchers.yaml
@@ -10,7 +10,7 @@ metadata:
   language: java
   scwCategory: access:functionlevel
   enabled: true
-  descriptionFile: Java/Spring/Security/descriptions/Access_Control__MvcRequestMatcher_is_more_secure_than_AntPathRequestMatcher_for_Spring_MVC_patterns.html
+  descriptionFile: descriptions/Access_Control__MvcRequestMatcher_is_more_secure_than_AntPathRequestMatcher_for_Spring_MVC_patterns.html
   tags: spring;security;spring-mvc;spring-security;access-control
 search:
   methodcall:

--- a/recipes/Java/Spring/Security/descriptions/Access_Control__MvcRequestMatcher_is_more_secure_than_AntPathRequestMatcher_for_Spring_MVC_patterns.html
+++ b/recipes/Java/Spring/Security/descriptions/Access_Control__MvcRequestMatcher_is_more_secure_than_AntPathRequestMatcher_for_Spring_MVC_patterns.html
@@ -1,6 +1,6 @@
 <html>
 <body>
-<p id="abstract">For endpoint authorization, it is recommended to use <code>mvcMatchers</code> instead of <code>antMatchers</code>, as it will provide authorization for all paths that the <code>@RequestMapping</code> annotation understands. In other words, <code>antMatchers</code> will only authorise <code>/admin</code>, and leave <code>/admin/</code>, which leads to the same endpoint, accessible for unauthorised users. <code>mvcMatchers</code> will protect both paths.</p>
+<p id="abstract">For endpoint authorisation, it is recommended to use <code>mvcMatchers</code> instead of <code>antMatchers</code>, as it will provide authorisation for all paths that the <code>@RequestMapping</code> annotation understands. In other words, <code>antMatchers</code> will only authorise <code>/admin</code>, and leave <code>/admin/</code>, which leads to the same endpoint, accessible for unauthorised users. <code>mvcMatchers</code> will protect both paths.</p>
 <br>
 <b>Before</b>
 <pre>http.authorizeRequests().antMatchers(“/admin”).hasRole("ADMIN");</pre>

--- a/recipes/Java/Spring/Security/descriptions/Access_Control__MvcRequestMatcher_is_more_secure_than_AntPathRequestMatcher_for_Spring_MVC_patterns.html
+++ b/recipes/Java/Spring/Security/descriptions/Access_Control__MvcRequestMatcher_is_more_secure_than_AntPathRequestMatcher_for_Spring_MVC_patterns.html
@@ -3,10 +3,10 @@
 <p id="abstract">For endpoint authorisation, it is recommended to use <code>mvcMatchers</code> instead of <code>antMatchers</code>, as it will provide authorisation for all paths that the <code>@RequestMapping</code> annotation understands. In other words, <code>antMatchers</code> will only authorise <code>/admin</code>, and leave <code>/admin/</code>, which leads to the same endpoint, accessible for unauthorised users. <code>mvcMatchers</code> will protect both paths.</p>
 <br>
 <b>Before</b>
-<pre>http.authorizeRequests().antMatchers(“/admin”).hasRole("ADMIN");</pre>
+<pre>http.authorizeRequests().<b>ant</b>Matchers(“/admin”).hasRole("ADMIN");</pre>
 <br>
 <b>After</b>
-<pre>http.authorizeRequests().mvcMatchers(“/admin”).hasRole("ADMIN");</pre>
+<pre>http.authorizeRequests().<b>mvc</b>Matchers(“/admin”).hasRole("ADMIN");</pre>
 <br>
 <b>Resources</b>
 <ul>

--- a/recipes/Java/Spring/Security/descriptions/Access_Control__MvcRequestMatcher_is_more_secure_than_AntPathRequestMatcher_for_Spring_MVC_patterns.html
+++ b/recipes/Java/Spring/Security/descriptions/Access_Control__MvcRequestMatcher_is_more_secure_than_AntPathRequestMatcher_for_Spring_MVC_patterns.html
@@ -1,0 +1,16 @@
+<html>
+<body>
+<p id="abstract">For endpoint authorization, it is recommended to use <code>mvcMatchers</code> instead of <code>antMatchers</code>, as it will provide authorization for all paths that the <code>@RequestMapping</code> annotation understands. In other words, <code>antMatchers</code> will only authorise <code>/admin</code>, and leave <code>/admin/</code>, which leads to the same endpoint, accessible for unauthorised users. <code>mvcMatchers</code> will protect both paths.</p>
+<br>
+<b>Before</b>
+<pre>http.authorizeRequests().antMatchers(“/admin”).hasRole("ADMIN");</pre>
+<br>
+<b>After</b>
+<pre>http.authorizeRequests().mvcMatchers(“/admin”).hasRole("ADMIN");</pre>
+<br>
+<b>Resources</b>
+<ul>
+  <li><a href="https://docs.spring.io/spring-security/site/docs/current/api/org/springframework/security/config/annotation/web/builders/HttpSecurity.RequestMatcherConfigurer.html#mvcMatchers(java.lang.String...)">Spring docs - mvcMatchers</a></li>
+</ul>
+</body>
+</html>


### PR DESCRIPTION
* recipe to recommend mvcmatchers over antmatchers