### PR TITLE
Disable "Use XML schema" recipe

### DIFF
--- a/recipes/Java/XML/XML_Injection_Set_XML_schema.yaml
+++ b/recipes/Java/XML/XML_Injection_Set_XML_schema.yaml
@@ -7,7 +7,7 @@ metadata:
   language: java
   newCodeOnly: false
   scwCategory: injection:xml
-  enabled: true
+  enabled: false
   descriptionFile: descriptions/XML_Injection__Use_XML_schema.html
   tags: security;XML;basic protection set;injection;OWASP Top 10
 search:


### PR DESCRIPTION
This issue should not be an error for sure. The use of XML schema is often not feasible, and XML injection is really not common.

So I'm going to suggest we disable it for now, as I don't think it will be actionable in 90% of cases. 