### PR TITLE
Rename XML Secure Processing recipe

### DIFF
--- a/recipes/Java/XML/XXE/XXE_Set_missing_secure_processing.yaml
+++ b/recipes/Java/XML/XXE/XXE_Set_missing_secure_processing.yaml
@@ -1,15 +1,16 @@
 id: scw:xml:missing-secure-processing
 version: 10
 metadata:
-  name: 'XML Injection: Set missing secure processing feature'
-  shortDescription: Could lead to XML Injection
+  name: 'XXE: Set missing secure processing feature'
+  shortDescription: Could lead to XXE
   level: error
   language: java
   newCodeOnly: false
   scwCategory: injection:xml
+  cweCategory: 611
   enabled: true
-  descriptionFile: descriptions/java_enable_xml_secure_processing.html
-  tags: security;XML;basic protection set;injection;OWASP Top 10
+  descriptionFile: Java/XML/descriptions/java_enable_xml_secure_processing.html
+  tags: OWASP Top 10;XML;XXE;basic protection set;security
 search:
   methodcall:
     not:

--- a/recipes/Java/XML/XXE/XXE_Set_secure_processing_true.yaml
+++ b/recipes/Java/XML/XXE/XXE_Set_secure_processing_true.yaml
@@ -1,15 +1,15 @@
 id: scw:xml:secure-processing-true
 version: 10
 metadata:
-  name: 'XML Injection: Set secure processing feature to true'
-  shortDescription: Could lead to XML Injection
+  name: 'XXE: Set secure processing feature to true'
+  shortDescription: Could lead to XXE
   level: error
   language: java
   newCodeOnly: false
   scwCategory: injection:xml
   enabled: true
-  descriptionFile: descriptions/java_enable_xml_secure_processing.html
-  tags: security;XML;basic protection set;injection;OWASP Top 10
+  descriptionFile: Java/XML/descriptions/java_enable_xml_secure_processing.html
+  tags: security;XML;basic protection set;XXE;OWASP Top 10
 search:
   methodcall:
     args:

--- a/recipes/Java/XML/XXE/XXE_Set_secure_processing_true.yaml
+++ b/recipes/Java/XML/XXE/XXE_Set_secure_processing_true.yaml
@@ -7,6 +7,7 @@ metadata:
   language: java
   newCodeOnly: false
   scwCategory: injection:xml
+  cweCategory: 611
   enabled: true
   descriptionFile: Java/XML/descriptions/java_enable_xml_secure_processing.html
   tags: security;XML;basic protection set;XXE;OWASP Top 10


### PR DESCRIPTION
- Moving the Secure Processing Feature to the XXE folder
- Fixing up the description file after the move
- Fixing the description and tags

Note that this recipe only triggers when it has been explicitly disabled. In which case, I'd also suggest we consider enabling `newCodeOnly`.