### PR TITLE
SEN-2503 Recipes for Migration from Joda-Time DateTime to java.time

### DIFF
--- a/example_code/joda-time-to-java-time-examples/pom.xml
+++ b/example_code/joda-time-to-java-time-examples/pom.xml
@@ -47,6 +47,12 @@
         </dependency>
 -->
 
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.11.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/example_code/joda-time-to-java-time-examples/pom.xml
+++ b/example_code/joda-time-to-java-time-examples/pom.xml
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.11.1</version>
+            <version>3.21.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/example_code/joda-time-to-java-time-examples/src/main/java/includetimezone/DateTimeExamples.java
+++ b/example_code/joda-time-to-java-time-examples/src/main/java/includetimezone/DateTimeExamples.java
@@ -1,0 +1,400 @@
+package includetimezone;
+
+import org.joda.time.*;
+import org.joda.time.chrono.BuddhistChronology;
+import org.joda.time.chrono.ISOChronology;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoField;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Locale;
+import java.util.Optional;
+
+public class DateTimeExamples {
+
+    private DateTime dateTimeField;
+
+    public void constructors() {
+
+        // The following are arguments used in the Constructors below
+        Chronology chronology = BuddhistChronology.getInstance();
+        long longInstant = System.currentTimeMillis();
+        Object instantObject = new java.util.Date();
+        java.sql.Date sqlDate = java.sql.Date.valueOf("2020-02-20");
+        java.util.Date javaDate = new java.util.Date();
+        Calendar calendar = Calendar.getInstance();
+        DateTimeZone dateTimeZone = DateTimeZone.getDefault();
+        DateMidnight dateMidnight = DateMidnight.now();
+        DateTime dateTime = DateTime.now();
+        Instant instant = Instant.now();
+        MutableDateTime mutableDateTime = MutableDateTime.now();
+
+        DateTime noargs = new DateTime();
+
+        DateTime fromChronology = new DateTime(chronology);
+        DateTime fromDateTimeZone = new DateTime(dateTimeZone);
+
+        int year = 2021;
+        int month = 1;
+        int day = 15;
+        int hour = 12;
+        int minute = 34;
+        int second = 56;
+        int millis = 789;
+
+        DateTime fromParts = new DateTime(year, month, day, hour, minute);
+        DateTime fromPartsChronology = new DateTime(year, month, day, hour, minute, chronology);
+        DateTime fromPartsDateTimeZone = new DateTime(year, month, day, hour, minute, dateTimeZone);
+
+        DateTime fromPartsWithSeconds = new DateTime(year, month, day, hour, minute, second);
+        DateTime fromPartsChronologyWithSeconds = new DateTime(year, month, day, hour, minute, second, chronology);
+        DateTime fromPartsDateTimeZoneWithSeconds = new DateTime(year, month, day, hour, minute, second, dateTimeZone);
+
+        DateTime fromPartsWithMillis = new DateTime(year, month, day, hour, minute, second, millis);
+        DateTime fromPartsChronologyWithMillis = new DateTime(year, month, day, hour, minute, second, millis, chronology);
+        DateTime fromPartsDateTimeZoneWithMillis = new DateTime(year, month, day, hour, minute, second, millis, dateTimeZone);
+
+        DateTime fromInstant = new DateTime(longInstant);
+        DateTime fromInstantChronology = new DateTime(longInstant, chronology);
+        DateTime fromInstantDateTimeZone = new DateTime(longInstant, dateTimeZone);
+
+        DateTime fromObject = new DateTime(instantObject);
+        DateTime fromObjectChronology = new DateTime(instantObject, chronology);
+        DateTime fromObjectDateTimeZone = new DateTime(instantObject, dateTimeZone);
+
+    }
+
+    public void constructorsObject() {
+
+        java.sql.Date sqlDate = java.sql.Date.valueOf("2020-02-20");
+        java.util.Date javaDate = new java.util.Date();
+        Calendar calendar = Calendar.getInstance();
+        DateMidnight dateMidnight = DateMidnight.now();
+        DateTime dateTime = DateTime.now();
+        Instant instant = Instant.now();
+        MutableDateTime mutableDateTime = MutableDateTime.now();
+        Object unknownObject = "whatever";
+
+        // The following should have an information only recipe stating migration cannot occur until
+        // the object is converted to something compatible
+        DateTime fromUnknownObject = new DateTime(unknownObject);
+
+        // The Following are all different migration cases for new DateTime(Object)
+        DateTime fromObjectString = new DateTime("string");
+        DateTime fromObjectCalendar = new DateTime(calendar);
+        DateTime fromSqlDate = new DateTime(sqlDate);
+        DateTime fromJavaDate = new DateTime(javaDate);
+        DateTime fromObjectLong = new DateTime(Long.valueOf(123));
+        DateTime fromObjectNull = new DateTime((Object)null);
+
+        // These ReadableInstant constructors should show an information only recipe 'Migrate the argument to
+        // java.time first'
+        DateTime fromObjectReadableInstantDateMidnight = new DateTime(mutableDateTime);
+        DateTime fromObjectReadableInstantDateTime = new DateTime(dateTime);
+        DateTime fromObjectReadableInstantInstant = new DateTime(instant);
+        DateTime fromObjectReadableInstantMutableDateTime = new DateTime(mutableDateTime);
+
+        // These Show the Readable Instant Constructors after migrating the arguments, and the migration fixes
+        // should be available
+        DateTime fromObjectReadableInstantZonedDateTime = new DateTime(java.time.ZonedDateTime.now());
+        DateTime fromObjectReadableInstantOffsetDateTime = new DateTime(java.time.OffsetDateTime.now());
+        DateTime fromObjectReadableInstantMigratedInstant = new DateTime(java.time.Instant.now());
+
+
+
+    }
+
+    public void constructorsObjectDateTimeZone(DateTimeZone dateTimeZone) {
+
+        java.sql.Date sqlDate = java.sql.Date.valueOf("2020-02-20");
+        java.util.Date javaDate = new java.util.Date();
+        Calendar calendar = Calendar.getInstance();
+        DateMidnight dateMidnight = DateMidnight.now();
+        DateTime dateTime = DateTime.now();
+        Instant instant = Instant.now();
+        MutableDateTime mutableDateTime = MutableDateTime.now();
+        Object unknownObject = "whatever";
+
+        // The following should have an information only recipe stating migration cannot occur until
+        // the object is converted to something compatible
+        DateTime fromUnknownObject = new DateTime(unknownObject, dateTimeZone);
+
+        // The Following are all different migration cases for new DateTime(Object, DateTimeZone)
+        DateTime fromObjectString = new DateTime("string", dateTimeZone);
+        DateTime fromObjectCalendar = new DateTime(calendar, dateTimeZone);
+        DateTime fromJavaDate = new DateTime(javaDate, dateTimeZone);
+        DateTime fromObjectLong = new DateTime(Long.valueOf(123), dateTimeZone);
+
+        // These ReadableInstant constructors should show an information only recipe 'Migrate the argument to
+        // java.time first'
+        DateTime fromObjectReadableInstantDateMidnight = new DateTime(mutableDateTime, dateTimeZone);
+        DateTime fromObjectReadableInstantDateTime = new DateTime(dateTime, dateTimeZone);
+        DateTime fromObjectReadableInstantInstant = new DateTime(instant, dateTimeZone);
+        DateTime fromObjectReadableInstantMutableDateTime = new DateTime(mutableDateTime, dateTimeZone);
+
+        // These Show the Readable Instant Constructors after migrating the arguments, and the migration fixes
+        // should be available
+        DateTime fromObjectReadableInstantZonedDateTime = new DateTime(java.time.ZonedDateTime.now(), dateTimeZone);
+        DateTime fromObjectReadableInstantOffsetDateTime = new DateTime(java.time.OffsetDateTime.now(), dateTimeZone);
+        DateTime fromObjectReadableInstantMigratedInstant = new DateTime(java.time.Instant.now(), dateTimeZone);
+
+    }
+
+    public void factoryMethods() {
+
+        // These variables are used in the factory methods below
+        Chronology chronology = ISOChronology.getInstance();
+        DateTimeZone dateTimeZone = DateTimeZone.UTC;
+        DateTimeFormatter dtf = DateTimeFormat.fullDate();
+
+        // now factory methods
+        DateTime dtnow = DateTime.now();
+        DateTime dtNowChronology = DateTime.now(chronology);
+        DateTime dtNowDateTimeZone = DateTime.now(dateTimeZone);
+
+        // parse factory methods
+        DateTime dtParsed = DateTime.parse("somedate");
+        DateTime dtParsedFormatter = DateTime.parse("somedate", dtf);
+
+    }
+
+    public DateTime getCreatedAt() {
+        return dateTimeField;
+    }
+
+    public Optional<DateTime> getSentAt() {
+        return Optional.ofNullable(dateTimeField);
+    }
+
+    public void methods(DateTime dateTime) {
+
+        // These variables are used as arguments in the methods below
+        DateTimeFieldType datetimefieldtypeArg = DateTimeFieldType.monthOfYear();
+
+        // Property accessors
+        DateTime.Property property = dateTime.property(datetimefieldtypeArg);
+        DateTime.Property propCenturyOfEra = dateTime.centuryOfEra();
+        DateTime.Property propDayOfMonth = dateTime.dayOfMonth();
+        DateTime.Property propDayOfWeek = dateTime.dayOfWeek();
+        DateTime.Property propDayOfYear = dateTime.dayOfYear();
+        DateTime.Property propEra = dateTime.era();
+        DateTime.Property propHourOfDay = dateTime.hourOfDay();
+        DateTime.Property propMillisOfDay = dateTime.millisOfDay();
+        DateTime.Property propMillisOfSecond = dateTime.millisOfSecond();
+        DateTime.Property propMinuteOfDay = dateTime.minuteOfDay();
+        DateTime.Property propMinuteOfHour = dateTime.minuteOfHour();
+        DateTime.Property propMonthOfYear = dateTime.monthOfYear();
+        DateTime.Property propSecondOfDay = dateTime.secondOfDay();
+        DateTime.Property propSecondOfMinute = dateTime.secondOfMinute();
+        DateTime.Property propWeekOfWeekYear = dateTime.weekOfWeekyear();
+        DateTime.Property propWeekyear = dateTime.weekyear();
+        DateTime.Property propYear = dateTime.year();
+        DateTime.Property propYearOfCentury = dateTime.yearOfCentury();
+        DateTime.Property propYearOfEra = dateTime.yearOfEra();
+    }
+
+    public void getMethods(DateTime dateTime) {
+
+        // These variables are used as arguments in the methods below
+        DateTimeFieldType datetimefieldtypeArg = DateTimeFieldType.monthOfYear();
+        DateTimeField datetimefieldArg = null;
+
+        // Get methods
+        org.joda.time.Chronology getChronology = dateTime.getChronology();
+        long getMillis = dateTime.getMillis();
+        int getMillisOfDay = dateTime.getMillisOfDay();
+        int getMonthOfYear = dateTime.getMonthOfYear();
+        int getHourOfDay = dateTime.getHourOfDay();
+        int getMinuteOfHour = dateTime.getMinuteOfHour();
+        int getSecondOfMinute = dateTime.getSecondOfMinute();
+        int getMillisOfSecond = dateTime.getMillisOfSecond();
+        int getDayOfWeek = dateTime.getDayOfWeek();
+        int getDayOfYear = dateTime.getDayOfYear();
+        int getWeekOfWeekyear = dateTime.getWeekOfWeekyear();
+        int getWeekyear = dateTime.getWeekyear();
+        int getYearOfEra = dateTime.getYearOfEra();
+        int getYearOfCentury = dateTime.getYearOfCentury();
+        int getCenturyOfEra = dateTime.getCenturyOfEra();
+        int getEra = dateTime.getEra();
+        int getSecondOfDay = dateTime.getSecondOfDay();
+        int getMinuteOfDay = dateTime.getMinuteOfDay();
+        int get = dateTime.get(datetimefieldtypeArg);
+        int getYear = dateTime.getYear();
+        int getDayOfMonth = dateTime.getDayOfMonth();
+        DateTimeZone getZone = dateTime.getZone();
+        int getDateTimeField = dateTime.get(datetimefieldArg);
+    }
+
+    public void minusMethods(DateTime dateTime) {
+
+        // These variables are used as arguments in the methods below
+        ReadableDuration readableDuration = null;
+        ReadablePeriod readablePeriod = null;
+
+        // Minus Methods
+        DateTime dateTimeMinusLong = dateTime.minus(123L);
+        DateTime dateTimeMinusReadableDuration = dateTime.minus(readableDuration);
+        DateTime dateTimeMinusReadablePeriod = dateTime.minus(readablePeriod);
+        DateTime dateTimeMinusYears = dateTime.minusYears(2);
+        DateTime dateTimeMinusMonths = dateTime.minusMonths(5);
+        DateTime dateTimeMinusWeeks = dateTime.minusWeeks(5);
+        DateTime dateTimeMinusDays = dateTime.minusDays(5);
+        DateTime dateTimeMinusHours = dateTime.minusHours(5);
+        DateTime dateTimeMinusMinutes = dateTime.minusMinutes(560);
+        DateTime dateTimeMinusSeconds = dateTime.minusSeconds(45);
+        DateTime dateTimeMinusMillis = dateTime.minusMillis(500);
+
+    }
+
+    public void plusMethods(DateTime dateTime) {
+
+        // These variables are used as arguments in the methods below
+        Duration duration = Duration.ZERO;
+        Period period = Period.ZERO;
+
+        // Plus Methods
+        DateTime dateTimePlusLong = dateTime.plus(123L);
+        DateTime dateTimePlusReadableDuration = dateTime.plus(duration);
+        DateTime dateTimePlusReadablePeriod = dateTime.plus(period);
+        DateTime dateTimePlusDays = dateTime.plusDays(5);
+        DateTime dateTimePlusHours = dateTime.plusHours(5);
+        DateTime dateTimePlusMillis = dateTime.plusMillis(500);
+        DateTime dateTimePlusMinutes = dateTime.plusMinutes(560);
+        DateTime dateTimePlusMonths = dateTime.plusMonths(5);
+        DateTime dateTimePlusSeconds = dateTime.plusSeconds(45);
+        DateTime dateTimePlusWeeks = dateTime.plusWeeks(5);
+        DateTime dateTimePlusYears = dateTime.plusYears(2);
+    }
+
+    public void toMethods(DateTime dateTime) {
+        // These variables are used as arguments in the methods below
+        Locale localeArg = Locale.getDefault();
+        DateTimeZone dateTimeZone = DateTimeZone.UTC;
+        Chronology chronology = BuddhistChronology.getInstance();
+        DateTimeFormatter datetimeformatterArg = DateTimeFormat.fullDate();
+
+        // to methods
+        DateTime toDateTime = dateTime.toDateTime();
+        DateMidnight dateMidnight = dateTime.toDateMidnight();
+        DateTime dateTimeFromChronology = dateTime.toDateTime(chronology);
+        DateTime dateTimeFromDateTimeZone = dateTime.toDateTime(dateTimeZone);
+        DateTime dateTimeIso = dateTime.toDateTimeISO();
+        LocalDate localDate = dateTime.toLocalDate();
+        LocalDateTime localDateTime = dateTime.toLocalDateTime();
+        LocalTime localTime = dateTime.toLocalTime();
+        TimeOfDay timeOfDay = dateTime.toTimeOfDay();
+        YearMonthDay yearMonthDay = dateTime.toYearMonthDay();
+        java.util.Calendar toCalendar = dateTime.toCalendar(localeArg);
+        java.util.GregorianCalendar toGregorianCalendar = dateTime.toGregorianCalendar();
+        java.util.Date toDate = dateTime.toDate();
+        org.joda.time.Instant toInstant = dateTime.toInstant();
+
+        MutableDateTime toMutableDateTime1 = dateTime.toMutableDateTime(chronology);
+        MutableDateTime toMutableDateTime2 = dateTime.toMutableDateTime();
+        MutableDateTime toMutableDateTime3 = dateTime.toMutableDateTime(dateTimeZone);
+        MutableDateTime toMutableDateTimeISO = dateTime.toMutableDateTimeISO();
+
+        // toString methods
+        String toString1 = dateTime.toString();
+        String toString2 = dateTime.toString("pattern");
+        String toString3 = dateTime.toString("pattern", localeArg);
+        String toString4 = dateTime.toString(datetimeformatterArg);
+    }
+
+    public void withMethods(DateTime dateTime) {
+        // These variables are used as arguments in the methods below
+        ReadableDuration readableDuration = null;
+        ReadablePeriod readablePeriod = null;
+        ReadablePartial readablePartial = null;
+        ReadableInstant readableInstant = null;
+        Object objectArg = null;
+        Locale localeArg = Locale.getDefault();
+        DateTimeZone dateTimeZone = DateTimeZone.UTC;
+        Chronology chronology = BuddhistChronology.getInstance();
+        DateTimeFieldType datetimefieldtypeArg = DateTimeFieldType.monthOfYear();
+        DateTimeField datetimefieldArg = null;
+        DateTimeFormatter datetimeformatterArg = DateTimeFormat.fullDate();
+        LocalDate localDate = LocalDate.now();
+        LocalTime localTime = LocalTime.now();
+
+        // with
+        DateTime withDateLocalDate = dateTime.withDate(localDate);
+        DateTime withDateParts = dateTime.withDate(2020, 2, 35);
+
+        DateTime withTime = dateTime.withTime(6, 7, 8, 123);
+        DateTime withTimeLocalTime = dateTime.withTime(localTime);
+        DateTime withTimeAtStartOfDay = dateTime.withTimeAtStartOfDay();
+
+        DateTime withCenturyOfEra = dateTime.withCenturyOfEra(5);
+        DateTime withDayOfMonth = dateTime.withDayOfMonth(5);
+        DateTime withDayOfWeek = dateTime.withDayOfWeek(5);
+        DateTime withDayOfYear = dateTime.withDayOfYear(6);
+        DateTime withEra = dateTime.withEra(5);
+        DateTime withHourOfDay = dateTime.withHourOfDay(5);
+        DateTime withMillisInt = dateTime.withMillis(123);
+        DateTime withMillisLong = dateTime.withMillis(123L);
+        DateTime withMillisOfDay = dateTime.withMillisOfDay(1234);
+        DateTime withMillisOfSecond = dateTime.withMillisOfSecond(531);
+        DateTime withMinuteOfHour = dateTime.withMinuteOfHour(30);
+        DateTime withMonthOfYear = dateTime.withMonthOfYear(2);
+        DateTime withSecondOfMinute = dateTime.withSecondOfMinute(50);
+        DateTime withWeekOfWeekYear = dateTime.withWeekOfWeekyear(5);
+        DateTime withWeekyear = dateTime.withWeekyear(6);
+        DateTime withYear = dateTime.withYear(1236);
+        DateTime withYearOfCentury = dateTime.withYearOfCentury(56);
+        DateTime withYearOfEra = dateTime.withYearOfEra(56);
+
+        DateTime withDurationAdded = dateTime.withDurationAdded(23L, 3);
+        DateTime withDurationAddedRd = dateTime.withDurationAdded(readableDuration, 5);
+        DateTime withPeriodAdded = dateTime.withPeriodAdded(readablePeriod, 5);
+
+        DateTime withField = dateTime.withField(DateTimeFieldType.dayOfMonth(), 5);
+        DateTime withFieldAdded = dateTime.withFieldAdded(DurationFieldType.hours(), 5);
+        DateTime withFields = dateTime.withFields(readablePartial);
+
+        DateTime withEarlierOffsetAtOverlap = dateTime.withEarlierOffsetAtOverlap();
+        DateTime withLaterOffsetAtOverlap = dateTime.withLaterOffsetAtOverlap();
+
+        DateTime withChronology = dateTime.withChronology(chronology);
+
+        DateTime withZone = dateTime.withZone(dateTimeZone);
+        DateTime withZoneRetainFields = dateTime.withZoneRetainFields(dateTimeZone);
+    }
+
+    public void isMethods(DateTime dateTime) {
+
+        // These variables are used as arguments in the methods below
+        ReadableInstant readableInstant = null;
+        DateTimeFieldType datetimefieldtypeArg = DateTimeFieldType.monthOfYear();
+
+        // is methods
+        boolean isAfter1 = dateTime.isAfter(readableInstant);
+        boolean isAfter2 = dateTime.isAfter(123456L);
+        boolean isBefore1 = dateTime.isBefore(123456L);
+        boolean isBefore2 = dateTime.isBefore(readableInstant);
+        boolean isEqual1 = dateTime.isEqual(readableInstant);
+        boolean isEqual2 = dateTime.isEqual(123456L);
+        boolean isAfterNow = dateTime.isAfterNow();
+        boolean isBeforeNow = dateTime.isBeforeNow();
+        boolean isEqualNow = dateTime.isEqualNow();
+        boolean isSupported = dateTime.isSupported(datetimefieldtypeArg);
+
+    }
+
+    public void compareMethods(DateTime dateTime) {
+
+        // These variables are used as arguments in the methods below
+        ReadableInstant readableInstant = null;
+
+        // Compare to
+        int compareTo2 = dateTime.compareTo(readableInstant);
+
+
+    }
+
+
+}

--- a/example_code/joda-time-to-java-time-examples/src/main/java/includetimezone/DateTimeExamples.java
+++ b/example_code/joda-time-to-java-time-examples/src/main/java/includetimezone/DateTimeExamples.java
@@ -6,11 +6,7 @@ import org.joda.time.chrono.ISOChronology;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-import java.time.temporal.ChronoField;
 import java.util.Calendar;
-import java.util.Date;
 import java.util.Locale;
 import java.util.Optional;
 
@@ -89,7 +85,7 @@ public class DateTimeExamples {
         DateTime fromSqlDate = new DateTime(sqlDate);
         DateTime fromJavaDate = new DateTime(javaDate);
         DateTime fromObjectLong = new DateTime(Long.valueOf(123));
-        DateTime fromObjectNull = new DateTime((Object)null);
+        DateTime fromObjectNull = new DateTime((Object) null);
 
         // These ReadableInstant constructors should show an information only recipe 'Migrate the argument to
         // java.time first'
@@ -103,8 +99,6 @@ public class DateTimeExamples {
         DateTime fromObjectReadableInstantZonedDateTime = new DateTime(java.time.ZonedDateTime.now());
         DateTime fromObjectReadableInstantOffsetDateTime = new DateTime(java.time.OffsetDateTime.now());
         DateTime fromObjectReadableInstantMigratedInstant = new DateTime(java.time.Instant.now());
-
-
 
     }
 
@@ -363,6 +357,7 @@ public class DateTimeExamples {
 
         DateTime withZone = dateTime.withZone(dateTimeZone);
         DateTime withZoneRetainFields = dateTime.withZoneRetainFields(dateTimeZone);
+
     }
 
     public void isMethods(DateTime dateTime) {
@@ -393,8 +388,6 @@ public class DateTimeExamples {
         // Compare to
         int compareTo2 = dateTime.compareTo(readableInstant);
 
-
     }
-
 
 }

--- a/example_code/joda-time-to-java-time-examples/src/test/java/includetimezone/DateTimeConstructorsTest.java
+++ b/example_code/joda-time-to-java-time-examples/src/test/java/includetimezone/DateTimeConstructorsTest.java
@@ -1,0 +1,753 @@
+package includetimezone;
+
+import org.joda.time.*;
+import org.junit.jupiter.api.Test;
+
+import java.time.*;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoField;
+import java.time.temporal.TemporalAccessor;
+import java.util.Calendar;
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class DateTimeConstructorsTest {
+
+    /*
+        This test is written in support of the recipe:
+            DateTime-constructor-year-month-day-hour-minute-second-millis.yaml
+    */
+    @Test
+    public void test_year_month_day_hour_minute_second_millis() {
+
+        int year = 2021;
+        int month = 11;
+        int day = 8;
+        int hour = 12;
+        int minute = 34;
+        int seconds = 56;
+        int millis = 789;
+
+        DateTime dateTime = new DateTime(year, month, day, hour, minute, seconds, millis);
+        ZonedDateTime zonedDateTime = ZonedDateTime.of(year, month, day, hour, minute, seconds, 0, ZoneId.systemDefault()).with(ChronoField.MILLI_OF_SECOND, millis);
+
+        assertSameInstant(dateTime, zonedDateTime.toInstant());
+        assertSameZoneId(dateTime, zonedDateTime);
+
+    }
+
+    /*
+        This test is written in support of the recipe:
+            DateTime-constructor-year-month-day-hour-minute-second-millis-DateTimeZone.yaml
+    */
+
+    @Test
+    public void test_year_month_day_hour_minute_second_millis_DateTimeZone() {
+
+        String id = "Indian/Maldives";
+        DateTimeZone dateTimeZone = DateTimeZone.forID(id);
+        // This is the equivalent zone as would be migrated by: datetimezone-zoneid-forid.yaml
+        ZoneId zoneId = ZoneId.of(id);
+
+        int year = 2021;
+        int month = 11;
+        int day = 8;
+        int hour = 12;
+        int minute = 34;
+        int seconds = 56;
+        int millis = 789;
+
+        DateTime dateTime = new DateTime(year, month, day, hour, minute, seconds, millis, dateTimeZone);
+        ZonedDateTime zonedDateTime = ZonedDateTime.of(year, month, day, hour, minute, seconds, 0, zoneId).with(ChronoField.MILLI_OF_SECOND, millis);
+
+        assertSameInstant(dateTime, zonedDateTime.toInstant());
+        assertSameZoneId(dateTime, zonedDateTime);
+
+    }
+
+    /*
+    This test is written in support of the recipe:
+        DateTime-constructor-year-month-day-hour-minute-second.yaml
+*/
+    @Test
+    public void test_year_month_day_hour_minute_second() {
+
+        int year = 2021;
+        int month = 11;
+        int day = 8;
+        int hour = 12;
+        int minute = 34;
+        int seconds = 56;
+
+        DateTime dateTime = new DateTime(year, month, day, hour, minute, seconds);
+        ZonedDateTime zonedDateTime = ZonedDateTime.of(year, month, day, hour, minute, seconds, 0, ZoneId.systemDefault());
+
+        assertSameInstant(dateTime, zonedDateTime.toInstant());
+        assertSameZoneId(dateTime, zonedDateTime);
+
+    }
+
+    /*
+        This test is written in support of the recipe:
+            DateTime-constructor-year-month-day-hour-minute-second-DateTimeZone.yaml
+    */
+
+    @Test
+    public void test_year_month_day_hour_minute_second_DateTimeZone() {
+
+        String id = "Indian/Maldives";
+        DateTimeZone dateTimeZone = DateTimeZone.forID(id);
+        // This is the equivalent zone as would be migrated by: datetimezone-zoneid-forid.yaml
+        ZoneId zoneId = ZoneId.of(id);
+
+        int year = 2021;
+        int month = 11;
+        int day = 8;
+        int hour = 12;
+        int minute = 34;
+        int seconds = 56;
+
+        DateTime dateTime = new DateTime(year, month, day, hour, minute, seconds, dateTimeZone);
+        ZonedDateTime zonedDateTime = ZonedDateTime.of(year, month, day, hour, minute, seconds, 0, zoneId);
+
+        assertSameInstant(dateTime, zonedDateTime.toInstant());
+        assertSameZoneId(dateTime, zonedDateTime);
+
+    }
+
+    /*
+        This test is written in support of the recipe:
+            DateTime-constructor-year-month-day-hour-minute.yaml
+    */
+    @Test
+    public void test_year_month_day_hour_minute() {
+
+        int year = 2021;
+        int month = 11;
+        int day = 8;
+        int hour = 12;
+        int minute = 34;
+
+        DateTime dateTime = new DateTime(year, month, day, hour, minute);
+        ZonedDateTime zonedDateTime = ZonedDateTime.of(year, month, day, hour, minute,0, 0, ZoneId.systemDefault());
+
+        assertSameInstant(dateTime, zonedDateTime.toInstant());
+        assertSameZoneId(dateTime, zonedDateTime);
+
+    }
+
+    /*
+        This test is written in support of the recipe:
+            DateTime-constructor-year-month-day-hour-minute-DateTimeZone.yaml
+    */
+    @Test
+    public void test_year_month_day_hour_minute_DateTimeZone() {
+
+        String id = "Indian/Maldives";
+        DateTimeZone dateTimeZone = DateTimeZone.forID(id);
+        // This is the equivalent zone as would be migrated by: datetimezone-zoneid-forid.yaml
+        ZoneId zoneId = ZoneId.of(id);
+
+        int year = 2021;
+        int month = 11;
+        int day = 8;
+        int hour = 12;
+        int minute = 34;
+
+        DateTime dateTime = new DateTime(year, month, day, hour, minute, dateTimeZone);
+        ZonedDateTime zonedDateTime = ZonedDateTime.of(year, month, day, hour, minute, 0, 0, zoneId);
+
+        assertSameInstant(dateTime, zonedDateTime.toInstant());
+        assertSameZoneId(dateTime, zonedDateTime);
+
+    }
+
+    /*
+        This test is written in support of the recipe:
+            DateTime-constructor-empty.yaml
+     */
+    @Test
+    public void test_empty() {
+
+        // Recipe searches for this
+        DateTime dateTime = new DateTime();
+
+        // ZonedDateTime fix transforms to this:
+        ZonedDateTime zonedDateTime = ZonedDateTime.now();
+        // OffsetDateTime fix transforms to this:
+        OffsetDateTime offsetDateTime = OffsetDateTime.now();
+
+        // Assert the ZonedDateTime is the same (within a second)
+        assertCloseToInstant(dateTime, zonedDateTime.toInstant());
+        assertSameZoneId(dateTime, zonedDateTime);
+
+        // Assert the offsetdatetime is the same (within a second)
+        assertCloseToInstant(dateTime, offsetDateTime.toInstant());
+        assertSameOffset(dateTime, offsetDateTime);
+
+    }
+
+
+    @Test
+    public void test_Constructor_DateMidnight() {
+
+        DateTime dateTime = new DateTime(DateMidnight.now());
+        ZonedDateTime zonedDateTime = ZonedDateTime.from(LocalDate.now().atStartOfDay(ZoneId.systemDefault()));
+
+        assertThat(dateTime.getMillis()).isEqualTo(zonedDateTime.toInstant().toEpochMilli());
+        assertThat(dateTime.getZone().getID()).isEqualTo(zonedDateTime.getZone().getId());
+
+    }
+
+    @Test
+    public void test_Constructor_DateTime() {
+
+        DateTime dateTime = new DateTime(DateTime.now().plusDays(2));
+        ZonedDateTime zonedDateTime = ZonedDateTime.from(ZonedDateTime.now().plusDays(2));
+
+    }
+
+    @Test
+    public void test_Constructor_MutableDateTime() {
+
+        long now = Clock.systemDefaultZone().millis();
+
+        DateTime dateTime = new DateTime(new MutableDateTime(now));
+        ZonedDateTime zonedDateTime = ZonedDateTime.from(ZonedDateTime.now());
+
+
+    }
+
+    @Test
+    public void test_Constructor_String() {
+
+        DateTimeFormatter dtf = java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd['T'HH:mm:ss.SSSX]");
+
+        String shortDate = "2021-09-08";
+        String fullDatetime = "2021-09-08T12:45:56.123Z";
+
+        DateTime dateTimeShortDate = new DateTime(shortDate);
+
+        System.out.println(dateTimeShortDate.toString());
+
+        DateTime dateTime = new DateTime(fullDatetime);
+
+        ZonedDateTime zdtShort = LocalDate.parse(shortDate).atStartOfDay(ZoneId.systemDefault());
+        ZonedDateTime zdt = ZonedDateTime.parse(fullDatetime, dtf);
+
+    }
+
+    @Test
+    public void test_Constructor_String_shortDate() {
+        /*
+        datetime          = time | date-opt-time
+        time              = 'T' time-element [offset]
+        date-opt-time     = date-element ['T' [time-element] [offset]]
+        date-element      = std-date-element | ord-date-element | week-date-element
+        std-date-element  = yyyy ['-' MM ['-' dd]]
+        ord-date-element  = yyyy ['-' DDD]
+        week-date-element = xxxx '-W' ww ['-' e]
+        time-element      = HH [minute-element] | [fraction]
+        minute-element    = ':' mm [second-element] | [fraction]
+        second-element    = ':' ss [fraction]
+        fraction          = ('.' | ',') digit+
+        offset            = 'Z' | (('+' | '-') HH [':' mm [':' ss [('.' | ',') SSS]]])
+         */
+
+        String standardDateElement = "2021-11-25";
+        String ordinalDateElement = "2021-300";
+        String weekDateElement = "2021-W05-6"; // Check This
+
+        String timeElementHoursOnly = "12";
+        String timeElementHourMinutes = "12:34";
+        String timeElementHourMinutesSeconds = "12:34:56";
+        String timeElementHourMinutesSecondsFractionPeriod = "12:34:56.789";
+        String timeElementHourMinutesSecondsFractionComma = "12:34:56,789";
+        String timeElementFractionOnlyWithPeriod = ".789";
+        String timeElementFractionOnlyWithComma = ",789";
+        String timeNoOffset = "Ttime-element";
+        String timeWithOffset = "Ttime-element[offset]";
+        String dateWithTimeNoOffset = "";
+        String dateWithOffsetNoTime = "";
+
+        //DateTime dateTimeShortDate = new DateTime(shortDate);
+        //System.out.println(dateTimeShortDate.toString());
+        //ZonedDateTime zdtShort = LocalDate.parse(shortDate).atStartOfDay(ZoneId.systemDefault());
+        //System.out.println(zdtShort.toString());
+
+        //(dateTimeShortDate.getMillis()).isEqualTo(zdtShort.toInstant().toEpochMilli());
+        //assertThat(dateTimeShortDate.getZone().getID()).isEqualTo(zdtShort.getZone().getId());
+
+
+    }
+
+
+    @Test
+    public void test_Constructor_String_DateTimeZone() {
+
+        String string = "2021-09-08T12:45:56";
+
+        DateTime dateTime = new DateTime(string);
+        //ZonedDateTime zonedDateTime = ZonedDateTime.parse(string, DateTimeFormatter.ISO_DATE_TIME);
+
+    }
+
+    /*
+        This test is written in support of the recipe:
+            DateTime-constructor-Calendar-DateTimeZone.yaml
+     */
+    @Test
+    public void test_Calendar_DateTimeZone() {
+
+        String id = "Indian/Maldives";
+        DateTimeZone dateTimeZone = DateTimeZone.forID(id);
+        // This is the equivalent zone as would be migrated by: datetimezone-zoneid-forid.yaml
+        ZoneId zoneId = ZoneId.of(id);
+
+        Calendar calendar = Calendar.getInstance();
+
+        // Recipe searches for this
+        DateTime dateTime = new DateTime(calendar, dateTimeZone);
+        // ZonedDateTime fix should transform to this (after DateTimeZone has also been migrated)
+        ZonedDateTime zonedDateTime = ZonedDateTime.ofInstant(calendar.toInstant(), zoneId);
+        // OffsetDateTime fix should transform to this (after DateTimeZone has also been migrated)
+        OffsetDateTime offsetDateTime = OffsetDateTime.ofInstant(calendar.toInstant(), zoneId);
+
+        // Assert ZonedDateTime is equivalent
+        assertSameInstant(dateTime, zonedDateTime.toInstant());
+        assertSameZoneId(dateTime, zonedDateTime);
+        // Assert OffsetDateTime is equivalent
+        assertSameInstant(dateTime, offsetDateTime.toInstant());
+        assertSameOffset(dateTime, offsetDateTime);
+
+    }
+
+    /*
+    This test is written in support of the recipe:
+        DateTime-constructor-Calendar.yaml
+    */
+    @Test
+    public void test_Calendar() {
+
+        String id = "Indian/Maldives";
+
+        Calendar calendar = Calendar.getInstance();
+
+        // Recipe searches for this
+        DateTime dateTime = new DateTime(calendar);
+        // ZonedDateTime fix should transform to this
+        ZonedDateTime zonedDateTime = ZonedDateTime.ofInstant(calendar.toInstant(), ZoneId.systemDefault());
+        // OffsetDateTime fix should transform to this
+        OffsetDateTime offsetDateTime = OffsetDateTime.ofInstant(calendar.toInstant(), ZoneId.systemDefault());
+
+        // Assert ZonedDateTime is equivalent
+        assertSameInstant(dateTime, zonedDateTime.toInstant());
+        assertSameZoneId(dateTime, zonedDateTime);
+        // Assert OffsetDateTime is equivalent
+        assertSameInstant(dateTime, offsetDateTime.toInstant());
+        assertSameOffset(dateTime, offsetDateTime);
+
+    }
+
+    /*
+    This test is written in support of the recipe:
+        DateTime-constructor-Date-DateTimeZone.yaml
+    */
+    @Test
+    public void test_Date_DateTimeZone() {
+
+        String id = "Indian/Maldives";
+        DateTimeZone dateTimeZone = DateTimeZone.forID(id);
+        ZoneId zoneId = ZoneId.of(id);
+        Date date = new Date();
+
+        // Recipe searches for this
+        DateTime dateTime = new DateTime(date, dateTimeZone);
+        // ZonedDateTime fix should transform to this (after DateTimeZone has also been migrated)
+        ZonedDateTime zonedDateTime = ZonedDateTime.ofInstant(date.toInstant(), zoneId);
+        // OffsetDateTime fix should transform to this (after DateTimeZone has also been migrated)
+        OffsetDateTime offsetDateTime = OffsetDateTime.ofInstant(date.toInstant(), zoneId);
+
+        // Assert ZonedDateTime is equivalent
+        assertSameInstant(dateTime, zonedDateTime.toInstant());
+        assertSameZoneId(dateTime, zonedDateTime);
+        // Assert OffsetDateTime is equivalent
+        assertSameInstant(dateTime, offsetDateTime.toInstant());
+        assertSameOffset(dateTime, offsetDateTime);
+
+
+    }
+
+    /*
+        This test is written in support of the recipe:
+            DateTime-constructor-Date.yaml
+    */
+    @Test
+    public void test_Date() {
+
+        Date date = new Date();
+
+        // Recipe searches for this
+        DateTime dateTime = new DateTime(date);
+        // ZonedDateTime fix should transform to this (after DateTimeZone has also been migrated)
+        ZonedDateTime zonedDateTime = ZonedDateTime.ofInstant(date.toInstant(), ZoneId.systemDefault());
+        // OffsetDateTime fix should transform to this (after DateTimeZone has also been migrated)
+        OffsetDateTime offsetDateTime = OffsetDateTime.ofInstant(date.toInstant(), ZoneId.systemDefault());
+
+        // Assert ZonedDateTime is equivalent
+        assertSameInstant(dateTime, zonedDateTime.toInstant());
+        assertSameZoneId(dateTime, zonedDateTime);
+        // Assert OffsetDateTime is equivalent
+        assertSameInstant(dateTime, offsetDateTime.toInstant());
+        assertSameOffset(dateTime, offsetDateTime);
+
+
+    }
+
+    /*
+        This test is written in support of the recipe:
+            DateTime-constructor-DateTimeZone.yaml
+    */
+    @Test
+    public void test_DateTimeZone() {
+
+        String id = "Indian/Maldives";
+        DateTimeZone dateTimeZone = DateTimeZone.forID(id);
+        ZoneId zoneId = ZoneId.of(id);
+
+        // Recipe searches for this
+        DateTime dateTime = new DateTime(dateTimeZone);
+        // ZonedDateTime fix should transform to this (after DateTimeZone has also been migrated)
+        ZonedDateTime zonedDateTime = ZonedDateTime.now(zoneId);
+        // OffsetDateTime fix should transform to this (after DateTimeZone has also been migrated)
+        OffsetDateTime offsetDateTime = OffsetDateTime.now(zoneId);
+
+        // Assert ZonedDateTime is equivalent
+        assertCloseToInstant(dateTime, zonedDateTime.toInstant());
+        assertSameZoneId(dateTime, zonedDateTime);
+        // Assert OffsetDateTime is equivalent
+        assertCloseToInstant(dateTime, offsetDateTime.toInstant());
+        assertSameOffset(dateTime, offsetDateTime);
+
+
+    }
+
+    /*
+        This test is written in support of the recipe:
+            DateTime-constructor-long-DateTimeZone.yaml
+    */
+    @Test
+    public void test_Long_DateTimeZone() {
+
+        String id = "Indian/Maldives";
+        DateTimeZone dateTimeZone = DateTimeZone.forID(id);
+        ZoneId zoneId = ZoneId.of(id);
+        Long longNow = Instant.now().toEpochMilli();
+
+        // Recipe searches for this
+        DateTime dateTime = new DateTime(longNow, dateTimeZone);
+        // ZonedDateTime fix transforms to this:
+        ZonedDateTime zonedDateTime = ZonedDateTime.ofInstant(Instant.ofEpochMilli(longNow), zoneId);
+        // OffsetDateTime fix transforms to this:
+        OffsetDateTime offsetDateTime = OffsetDateTime.ofInstant(Instant.ofEpochMilli(longNow), zoneId);
+
+        // ZonedDateTime should represent the same instant and Zone
+        assertSameInstant(dateTime, zonedDateTime.toInstant());
+        assertSameZoneId(dateTime, zonedDateTime);
+
+        // OffsetDateTime should represent same instant and offset
+        assertSameInstant(dateTime, offsetDateTime.toInstant());
+        assertSameOffset(dateTime, offsetDateTime);
+
+    }
+
+    /*
+        This test is written in support of the recipe:
+            DateTime-constructor-long.yaml
+    */
+    @Test
+    public void test_Long() {
+
+        Long longNow = Instant.now().toEpochMilli();
+
+        // Recipe searches for this
+        DateTime dateTime = new DateTime(longNow);
+        // ZonedDateTime fix transforms to this:
+        ZonedDateTime zonedDateTime = ZonedDateTime.ofInstant(Instant.ofEpochMilli(longNow), ZoneId.systemDefault());
+        // OffsetDateTime fix transforms to this:
+        OffsetDateTime offsetDateTime = OffsetDateTime.ofInstant(Instant.ofEpochMilli(longNow), ZoneId.systemDefault());
+
+        // ZonedDateTime should represent the same instant and Zone
+        assertSameInstant(dateTime, zonedDateTime.toInstant());
+        assertSameZoneId(dateTime, zonedDateTime);
+
+        // OffsetDateTime should represent same instant and offset
+        assertSameInstant(dateTime, offsetDateTime.toInstant());
+        assertSameOffset(dateTime, offsetDateTime);
+
+    }
+
+    /*
+        This test is written in support of the recipe:
+            DateTime-constructor-Instant-DateTimeZone.yaml
+    */
+    @Test
+    public void test_Instant_DateTimeZone() {
+
+        String id = "Indian/Maldives";
+        DateTimeZone dateTimeZone = DateTimeZone.forID(id);
+        ZoneId zoneId = ZoneId.of(id);
+        Long now = Instant.now().toEpochMilli();
+
+        // Equivalent Instants to use as arguments
+        org.joda.time.Instant jodaInstant = org.joda.time.Instant.ofEpochMilli(now);
+        Instant javaInstant = Instant.ofEpochMilli(now);
+
+        // Recipe searches for this
+        DateTime dateTime = new DateTime(jodaInstant, dateTimeZone);
+        // ZonedDateTime fix will transform to this:
+        ZonedDateTime zonedDateTime = ZonedDateTime.ofInstant(javaInstant, zoneId);
+        // OffsetDateTime fix will transform to this:
+        OffsetDateTime offsetDateTime = OffsetDateTime.ofInstant(javaInstant, zoneId);
+
+        // Assert ZonedDateTime is equivalent
+        assertSameInstant(dateTime, zonedDateTime.toInstant());
+        assertSameZoneId(dateTime, zonedDateTime);
+
+        // Assert OffsetDateTime is equivalent
+        assertSameInstant(dateTime, offsetDateTime.toInstant());
+        assertSameOffset(dateTime, offsetDateTime);
+
+    }
+
+    /*
+        This test is written in support of the recipe:
+            DateTime-constructor-Instant.yaml
+    */
+    @Test
+    public void test_Instant() {
+
+        Long now = Instant.now().toEpochMilli();
+
+        // Equivalent Instants to use as arguments
+        org.joda.time.Instant jodaInstant = org.joda.time.Instant.ofEpochMilli(now);
+        Instant javaInstant = Instant.ofEpochMilli(now);
+
+        // Recipe searches for this
+        DateTime dateTime = new DateTime(jodaInstant);
+        // ZonedDateTime fix will transform to this:
+        ZonedDateTime zonedDateTime = ZonedDateTime.ofInstant(javaInstant, ZoneId.of("UTC"));
+        // OffsetDateTime fix will transform to this:
+        OffsetDateTime offsetDateTime = OffsetDateTime.ofInstant(javaInstant, ZoneOffset.UTC);
+
+        // Assert ZonedDateTime is equivalent
+        assertSameInstant(dateTime, zonedDateTime.toInstant());
+        assertSameZoneId(dateTime, zonedDateTime);
+
+        // Assert OffsetDateTime is equivalent
+        assertSameInstant(dateTime, offsetDateTime.toInstant());
+        assertSameOffset(dateTime, offsetDateTime);
+
+    }
+
+    /*
+        This test is written in support of the recipe:
+            DateTime-constructor-TemporalAccessor-DateTimeZone.yaml
+        4 different scenarios that this recipe covers are tested, all of which require the first argument to have been
+        migrated to a java.time.temporal.TemporalAccessor before this recipe can match:
+            - new DateTime(DateTime, DateTimeZone) that was migrated to new DateTime(ZonedDateTime, DateTimeZone)
+            - new DateTime(DateTime, DateTimeZone) that was migrated to new DateTime(OffsetDateTime, DateTimeZone)
+            - new DateTime(DateMidnight, DateTimeZone) that was migrated to new DateTime(ZonedDateTime, DateTimeZone)
+            - new DateTime(MutableDateTime, DateTimeZone) that was migrated to new DateTime(ZonedDateTime, DateTimeZone)
+     */
+    @Test
+    public void test_TemporalAccessor_DateTimeZone() {
+
+        String id = "Indian/Maldives";
+        DateTimeZone dateTimeZone = DateTimeZone.forID(id);
+        Long now = Instant.now().toEpochMilli();
+
+        // Joda Objects to use as arguments
+        DateTime dateTime = new DateTime(now);
+        DateMidnight dateMidnight = dateTime.toDateMidnight();
+        MutableDateTime mutableDateTime = new MutableDateTime(now);
+
+        // The following java.time objects are obtained in the same fashion of their respective migration recipes
+
+        // - ZonedDateTime is an equivalent TemporalAccessor that can be migrated to from DateTime
+        ZonedDateTime zonedDateTime = ZonedDateTime.ofInstant(Instant.ofEpochMilli(now), ZoneId.systemDefault());
+        // - OffsetDateTime is an equivalent TemporalAccessor that can be migrated to from DateTime
+        OffsetDateTime offsetDateTime = OffsetDateTime.ofInstant(Instant.ofEpochMilli(now), ZoneId.systemDefault());
+        // - Joda DateMidnight can be migrated to this ZonedDateTime
+        ZonedDateTime zoneDateTimeMidnight = zonedDateTime.toLocalDate().atStartOfDay(zonedDateTime.getZone());
+
+
+        // Test that the datetime when migrated to the temporalAccessor ZonedDatetime is equivalent
+        test_ReadableInstant_and_TemporalAccessor(dateTime, zonedDateTime, dateTimeZone);
+        // Test that the datetime when migrated to the temporalAccessor OffsetDatetime is equivalent
+        test_ReadableInstant_and_TemporalAccessor(dateTime, offsetDateTime, dateTimeZone);
+        // Test that the dateMidnight when migrated to the TemporalAccessor ZonedDateTime is equivalent
+        test_ReadableInstant_and_TemporalAccessor(dateMidnight, zoneDateTimeMidnight, dateTimeZone);
+        // Test that the mutableDateTime when migrated to the TemporalAccessor ZonedDateTime is equivalent
+        test_ReadableInstant_and_TemporalAccessor(mutableDateTime, zonedDateTime, dateTimeZone);
+
+    }
+
+    /*
+        This method is written in support of recipe:
+            DateTime-constructor-TemporalAccessor-DateTimeZone.yaml
+
+        This method accepts a Joda-Time ReadableInstant, and an equivalent java.time TemporalAccessor that this
+        ReadableInstant would be migrated to.
+        It can use these 2 to verify that the transformation in the recipe is correct.
+     */
+    private void test_ReadableInstant_and_TemporalAccessor(ReadableInstant readableInstant, TemporalAccessor temporalAccessor, DateTimeZone dateTimeZone) {
+
+        ZoneId zoneId = ZoneId.of(dateTimeZone.getID());
+
+        DateTime dateTime = new DateTime(readableInstant, dateTimeZone);
+        ZonedDateTime zonedDateTime = ZonedDateTime.from(temporalAccessor).withZoneSameInstant(zoneId);
+
+        // Assert they are the same instant and ZoneId
+        assertSameInstant(dateTime, zonedDateTime.toInstant());
+        assertSameZoneId(dateTime, zonedDateTime);
+
+
+    }
+
+    /*
+        This test is written in support of the recipe:
+            DateTime-constructor-TemporalAccessor.yaml
+        4 different scenarios that this recipe covers are tested, all of which require the first argument to have been
+        migrated to a java.time.temporal.TemporalAccessor before this recipe can match:
+            - new DateTime(DateTime) that was migrated to new DateTime(ZonedDateTime)
+            - new DateTime(DateTime) that was migrated to new DateTime(OffsetDateTime)
+            - new DateTime(DateMidnight) that was migrated to new DateTime(ZonedDateTime)
+            - new DateTime(MutableDateTime) that was migrated to new DateTime(ZonedDateTime)
+     */
+    @Test
+    public void test_TemporalAccessor() {
+
+        Long now = Instant.now().toEpochMilli();
+
+        // Joda Objects to use as arguments
+        DateTime dateTime = new DateTime(now);
+        DateMidnight dateMidnight = dateTime.toDateMidnight();
+        MutableDateTime mutableDateTime = new MutableDateTime(now);
+
+        // The following java.time objects are obtained in the same fashion of their respective migration recipes
+
+        // - ZonedDateTime is an equivalent TemporalAccessor that can be migrated to from DateTime
+        ZonedDateTime zonedDateTime = ZonedDateTime.ofInstant(Instant.ofEpochMilli(now), ZoneId.systemDefault());
+        // - OffsetDateTime is an equivalent TemporalAccessor that can be migrated to from DateTime
+        OffsetDateTime offsetDateTime = OffsetDateTime.ofInstant(Instant.ofEpochMilli(now), ZoneId.systemDefault());
+        // - Joda DateMidnight can be migrated to this ZonedDateTime
+        ZonedDateTime zoneDateTimeMidnight = zonedDateTime.toLocalDate().atStartOfDay(zonedDateTime.getZone());
+
+
+        // Test that the datetime when migrated to the temporalAccessor ZonedDatetime is equivalent
+        test_ReadableInstant_and_TemporalAccessor(dateTime, zonedDateTime);
+        // Test that the datetime when migrated to the temporalAccessor OffsetDatetime is equivalent
+        test_ReadableInstant_and_TemporalAccessor_OffsetDateTime(dateTime, offsetDateTime);
+        // Test that the dateMidnight when migrated to the TemporalAccessor ZonedDateTime is equivalent
+        test_ReadableInstant_and_TemporalAccessor(dateMidnight, zoneDateTimeMidnight);
+        // Test that the mutableDateTime when migrated to the TemporalAccessor ZonedDateTime is equivalent
+        test_ReadableInstant_and_TemporalAccessor(mutableDateTime, zonedDateTime);
+
+    }
+
+    /*
+        This method is written in support of recipe:
+            DateTime-constructor-TemporalAccessor-DateTimeZone.yaml
+
+        This method accepts a Joda-Time ReadableInstant, and an equivalent java.time TemporalAccessor that this
+        ReadableInstant would be migrated to.
+        It can use these 2 to verify that the transformation in the recipe is correct.
+     */
+    private void test_ReadableInstant_and_TemporalAccessor(ReadableInstant readableInstant, TemporalAccessor temporalAccessor) {
+
+        DateTime dateTime = new DateTime(readableInstant);
+        ZonedDateTime zonedDateTime = ZonedDateTime.from(temporalAccessor);
+
+        // Assert they are the same instant and ZoneId
+        assertSameInstant(dateTime, zonedDateTime.toInstant());
+        assertSameZoneId(dateTime, zonedDateTime);
+
+
+    }
+
+    /*
+    This method is written in support of recipe:
+        DateTime-constructor-TemporalAccessor-DateTimeZone.yaml
+
+    This method accepts a Joda-Time ReadableInstant, and an equivalent java.time TemporalAccessor that this
+    ReadableInstant would be migrated to.
+    It can use these 2 to verify that the transformation in the recipe is correct.
+ */
+    private void test_ReadableInstant_and_TemporalAccessor_OffsetDateTime(ReadableInstant readableInstant, TemporalAccessor temporalAccessor) {
+
+        DateTime dateTime = new DateTime(readableInstant);
+        OffsetDateTime offsetDateTime = OffsetDateTime.from(temporalAccessor);
+
+        // Assert they are the same instant and ZoneId
+        assertSameInstant(dateTime, offsetDateTime.toInstant());
+        assertSameOffset(dateTime, offsetDateTime);
+
+
+    }
+
+    private void assertSameInstant(DateTime dateTime, java.time.Instant instant) {
+
+        // Both should represent the same instant
+        assertThat(dateTime.getMillis()).isEqualTo(instant.toEpochMilli());
+
+    }
+
+    /*
+        Used when we are testing .now(), just check our objects represent an instant within a second of each other
+        Possibly could use AOP to modify clock behaviour. There is a now(Clock clock) method
+        however we are specifically testing the other method signatures of now()
+     */
+    private void assertCloseToInstant(DateTime dateTime, java.time.Instant instant) {
+
+        // Both should represent almost the same instant
+        assertThat(dateTime.getMillis()).isCloseTo(instant.toEpochMilli(), within(1000L));
+
+    }
+
+    private void assertSameZoneId(DateTime dateTime, ZonedDateTime zonedDateTime) {
+
+        // Both should be in the same Zone
+        assertThat(dateTime.getZone().getID()).isEqualTo(zonedDateTime.getZone().getId());
+
+    }
+
+    private void assertSameOffset(DateTime dateTime, OffsetDateTime offsetDateTime) {
+
+        // Offsets should be the same. Use Joda Duration to compare
+        Duration jodaOffset = Duration.ofMillis(dateTime.getZone().getOffset(dateTime));
+        Duration javaOffset = Duration.ofSeconds(offsetDateTime.getOffset().getTotalSeconds());
+
+        assertThat(jodaOffset).isEqualTo(javaOffset);
+
+    }
+
+    @Test
+    public void offset() {
+        DateTime time = DateTime.now();
+
+        System.out.println(time.getZone().getOffset(time.getMillis()));
+
+        OffsetDateTime offsetDateTime = OffsetDateTime.now();
+
+        System.out.println(offsetDateTime.getOffset().getTotalSeconds());
+
+    }
+
+}

--- a/example_code/joda-time-to-java-time-examples/src/test/java/includetimezone/DateTimeConstructorsTest.java
+++ b/example_code/joda-time-to-java-time-examples/src/test/java/includetimezone/DateTimeConstructorsTest.java
@@ -3,10 +3,10 @@ package includetimezone;
 import org.joda.time.*;
 import org.junit.jupiter.api.Test;
 
-import java.time.*;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.*;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoField;
 import java.time.temporal.TemporalAccessor;
@@ -15,7 +15,6 @@ import java.util.Date;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class DateTimeConstructorsTest {
@@ -136,7 +135,7 @@ public class DateTimeConstructorsTest {
         int minute = 34;
 
         DateTime dateTime = new DateTime(year, month, day, hour, minute);
-        ZonedDateTime zonedDateTime = ZonedDateTime.of(year, month, day, hour, minute,0, 0, ZoneId.systemDefault());
+        ZonedDateTime zonedDateTime = ZonedDateTime.of(year, month, day, hour, minute, 0, 0, ZoneId.systemDefault());
 
         assertSameInstant(dateTime, zonedDateTime.toInstant());
         assertSameZoneId(dateTime, zonedDateTime);

--- a/example_code/joda-time-to-java-time-examples/src/test/java/includetimezone/DateTimeConstructorsTest.java
+++ b/example_code/joda-time-to-java-time-examples/src/test/java/includetimezone/DateTimeConstructorsTest.java
@@ -16,6 +16,7 @@ import java.util.Date;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class DateTimeConstructorsTest {
 
@@ -739,9 +740,20 @@ public class DateTimeConstructorsTest {
     }
 
     @Test
+    public void Instant_cannot_be_used_in_ZonedDateTime_from() {
 
+        Instant instant = Instant.now();
 
+        assertThrows(DateTimeException.class, () -> ZonedDateTime.from(instant));
 
+    }
+
+    @Test
+    public void Instant_cannot_be_used_in_OffsetDateTime_from() {
+
+        Instant instant = Instant.now();
+
+        assertThrows(DateTimeException.class, () -> OffsetDateTime.from(instant));
 
     }
 

--- a/example_code/joda-time-to-java-time-examples/src/test/java/includetimezone/DateTimeConstructorsTest.java
+++ b/example_code/joda-time-to-java-time-examples/src/test/java/includetimezone/DateTimeConstructorsTest.java
@@ -739,14 +739,9 @@ public class DateTimeConstructorsTest {
     }
 
     @Test
-    public void offset() {
-        DateTime time = DateTime.now();
 
-        System.out.println(time.getZone().getOffset(time.getMillis()));
 
-        OffsetDateTime offsetDateTime = OffsetDateTime.now();
 
-        System.out.println(offsetDateTime.getOffset().getTotalSeconds());
 
     }
 

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-Calendar-DateTimeZone.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-Calendar-DateTimeZone.yaml
@@ -1,0 +1,41 @@
+id: scw:java.time:Joda-Time:DateTime-constructor-Calendar-DateTimeZone
+version: 10
+metadata:
+  name: Migrate new DateTime(Calendar, DateTimeZone) to java.time
+  shortDescription: Migrate new DateTime(Calendar, DateTimeZone) to java.time
+  level: warning
+  language: java
+  enabled: true
+  comment: |
+    Searches for an instance creation of org.joda.time.DateTime and provides fixes to migrate to a java.time equivalent.
+
+    This recipe will cause broken code as part of an overall number of steps to perform a migration of Joda-Time to java.time.
+
+    After migrating this instance creation to the java.time equivalent, subsequent method calls and usages of the instance may become invalid.
+    Further Sensei recipes are available to help resolve many of these invalid usages.
+  descriptionFile: descriptions/datetime.html
+  tags: framework specific;java.time;Joda-Time;quality
+search:
+  instanceCreation:
+    args:
+      1:
+        type: java.util.Calendar
+      2:
+        anyOf:
+        - type: java.time.ZoneId
+        - type: org.joda.time.DateTimeZone
+    argCount: 2
+    type: org.joda.time.DateTime
+availableFixes:
+- name: Migrate to java.time.ZonedDateTime
+  actions:
+  - rewrite:
+      to: java.time.ZonedDateTime.ofInstant({{{ arguments.0 }}}.toInstant(), {{{ arguments.1 }}})
+  - modifyAssignedVariable:
+      type: java.time.ZonedDateTime
+- name: Migrate to java.time.OffsetDateTime
+  actions:
+  - rewrite:
+      to: java.time.OffsetDateTime.ofInstant({{{ arguments.0 }}}.toInstant(), {{{ arguments.1 }}})
+  - modifyAssignedVariable:
+      type: java.time.OffsetDateTime

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-Calendar.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-Calendar.yaml
@@ -1,0 +1,37 @@
+id: scw:java.time:Joda-Time:Datetime-constructor-Calendar
+version: 10
+metadata:
+  name: Migrate new DateTime(Calendar) to java.time
+  shortDescription: Migrate new DateTime(Calendar) to java.time
+  level: warning
+  language: java
+  enabled: true
+  comment: |
+    Searches for an instance creation of org.joda.time.DateTime and provides fixes to migrate to a java.time equivalent.
+
+    This recipe will cause broken code as part of an overall number of steps to perform a migration of Joda-Time to java.time.
+
+    After migrating this instance creation to the java.time equivalent, subsequent method calls and usages of the instance may become invalid.
+    Further Sensei recipes are available to help resolve many of these invalid usages.
+  descriptionFile: descriptions/datetime.html
+  tags: framework specific;java.time;Joda-Time;quality
+search:
+  instanceCreation:
+    args:
+      1:
+        type: java.util.Calendar
+    argCount: 1
+    type: org.joda.time.DateTime
+availableFixes:
+- name: Migrate to java.time.ZonedDateTime
+  actions:
+  - rewrite:
+      to: java.time.ZonedDateTime.ofInstant({{{ arguments.0 }}}.toInstant(), java.time.ZoneId.systemDefault())
+  - modifyAssignedVariable:
+      type: java.time.ZonedDateTime
+- name: Migrate to java.time.OffsetDateTime
+  actions:
+  - rewrite:
+      to: java.time.OffsetDateTime.ofInstant({{{ arguments.0 }}}.toInstant(), java.time.ZoneId.systemDefault())
+  - modifyAssignedVariable:
+      type: java.time.OffsetDateTime

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-Date-DateTimeZone.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-Date-DateTimeZone.yaml
@@ -1,0 +1,41 @@
+id: scw:java.time:Joda-Time:DateTime-constructor-Date-DateTimeZone
+version: 10
+metadata:
+  name: Migrate new DateTime(Date, DateTimeZone) to java.time
+  shortDescription: Migrate new DateTime(Date, DateTimeZone) to java.time
+  level: warning
+  language: java
+  enabled: true
+  comment: |
+    Searches for an instance creation of org.joda.time.DateTime and provides fixes to migrate to a java.time equivalent.
+
+    This recipe will cause broken code as part of an overall number of steps to perform a migration of Joda-Time to java.time.
+
+    After migrating this instance creation to the java.time equivalent, subsequent method calls and usages of the instance may become invalid.
+    Further Sensei recipes are available to help resolve many of these invalid usages.
+  descriptionFile: descriptions/datetime.html
+  tags: framework specific;java.time;Joda-Time;quality
+search:
+  instanceCreation:
+    args:
+      1:
+        type: java.util.Date
+      2:
+        anyOf:
+        - type: java.time.ZoneId
+        - type: org.joda.time.DateTimeZone
+    argCount: 2
+    type: org.joda.time.DateTime
+availableFixes:
+- name: Migrate to java.time ZonedDateTime
+  actions:
+  - rewrite:
+      to: java.time.ZonedDateTime.ofInstant({{{ arguments.0 }}}.toInstant(), {{{ arguments.1 }}})
+  - modifyAssignedVariable:
+      type: java.time.ZonedDateTime
+- name: Migrate to java.time.OffsetDateTime
+  actions:
+  - rewrite:
+      to: java.time.OffsetDateTime.ofInstant({{{ arguments.0 }}}.toInstant(), {{{ arguments.1 }}})
+  - modifyAssignedVariable:
+      type: java.time.OffsetDateTime

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-Date.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-Date.yaml
@@ -1,0 +1,37 @@
+id: scw:java.time:Joda-Time:DateTime-constructor-Date
+version: 10
+metadata:
+  name: Migrate new DateTime(Date) to java.time
+  shortDescription: Migrate new DateTime(Date) to java.time
+  level: warning
+  language: java
+  enabled: true
+  comment: |
+    Searches for an instance creation of org.joda.time.DateTime and provides fixes to migrate to a java.time equivalent.
+
+    This recipe will cause broken code as part of an overall number of steps to perform a migration of Joda-Time to java.time.
+
+    After migrating this instance creation to the java.time equivalent, subsequent method calls and usages of the instance may become invalid.
+    Further Sensei recipes are available to help resolve many of these invalid usages.
+  descriptionFile: descriptions/datetime.html
+  tags: framework specific;java.time;Joda-Time;quality
+search:
+  instanceCreation:
+    args:
+      1:
+        type: java.util.Date
+    argCount: 1
+    type: org.joda.time.DateTime
+availableFixes:
+- name: Migrate to java.time ZonedDateTime
+  actions:
+  - rewrite:
+      to: java.time.ZonedDateTime.ofInstant({{{ arguments.0 }}}.toInstant(), java.time.ZoneId.systemDefault())
+  - modifyAssignedVariable:
+      type: java.time.ZonedDateTime
+- name: Migrate to java.time OffsetDateTime
+  actions:
+  - rewrite:
+      to: java.time.OffsetDateTime.ofInstant({{{ arguments.0 }}}.toInstant(), java.time.ZoneId.systemDefault())
+  - modifyAssignedVariable:
+      type: java.time.OffsetDateTime

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-DateTimeZone.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-DateTimeZone.yaml
@@ -1,0 +1,40 @@
+id: scw:java.time:Joda-Time:DateTime-constructor-DateTimeZone
+version: 10
+metadata:
+  name: Migrate new DateTime(DateTimeZone) to java.time
+  shortDescription: Migrate new DateTime(DateTimeZone) to java.time
+  level: warning
+  language: java
+  enabled: true
+  comment: |+
+    Searches for an instance creation of org.joda.time.DateTime and provides fixes to migrate to a java.time equivalent.
+
+    This recipe is designed to match on broken code. The constructor originally accepts an org.joda.time.DateTimeZone argument, however this argument
+    should first be migrated to java.time.ZoneId using the DateTimeZone migration recipes.
+    This recipe will then match on the broken code, and the fixes in this recipe will allow the completion of the migration.
+
+    This recipe will cause broken code as part of an overall number of steps to perform a migration of Joda-Time to java.time.
+    After migrating this instance creation to the java.time equivalent, subsequent method calls and usages of the instance may become invalid.
+    Further Sensei recipes are available to help resolve many of these invalid usages.
+
+  descriptionFile: descriptions/datetime.html
+  tags: framework specific;java.time;Joda-Time;quality
+search:
+  instanceCreation:
+    args:
+      1:
+        type: java.time.ZoneId
+    type: org.joda.time.DateTime
+availableFixes:
+- name: Migrate to java.time.ZonedDateTime
+  actions:
+  - rewrite:
+      to: java.time.ZonedDateTime.now({{{ arguments.0 }}})
+  - modifyAssignedVariable:
+      type: java.time.ZonedDateTime
+- name: Migrate to java.time.OffsetDateTime
+  actions:
+  - rewrite:
+      to: java.time.OffsetDateTime.now({{{ arguments.0 }}})
+  - modifyAssignedVariable:
+      type: java.time.OffsetDateTime

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-DateTimeZone.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-DateTimeZone.yaml
@@ -6,7 +6,7 @@ metadata:
   level: warning
   language: java
   enabled: true
-  comment: |+
+  comment: |
     Searches for an instance creation of org.joda.time.DateTime and provides fixes to migrate to a java.time equivalent.
 
     This recipe is designed to match on broken code. The constructor originally accepts an org.joda.time.DateTimeZone argument, however this argument
@@ -16,7 +16,6 @@ metadata:
     This recipe will cause broken code as part of an overall number of steps to perform a migration of Joda-Time to java.time.
     After migrating this instance creation to the java.time equivalent, subsequent method calls and usages of the instance may become invalid.
     Further Sensei recipes are available to help resolve many of these invalid usages.
-
   descriptionFile: descriptions/datetime.html
   tags: framework specific;java.time;Joda-Time;quality
 search:

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-Instant-DateTimeZone.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-Instant-DateTimeZone.yaml
@@ -6,7 +6,16 @@ metadata:
   level: warning
   language: java
   enabled: true
-  comment: "This recipe is designed to match on broken code as part of an overall migration from Joda-Time to java.time.\n\nThe Instant and DateTimeZone arguments provided to this constructor will be required to be migrated to complete this migration. \nThis can be done before or after the migration of this constructor. This recipe detects both Joda-Time and java.time types for each argument 1 to allow this behaviour.\n\nThis recipe will cause broken code as part of an overall number of steps to perform a migration of Joda-Time to java.time.\n\nAfter migrating this instance creation to the java.time equivalent, subsequent method calls and usages of the instance may become invalid.\nFurther Sensei recipes are available to help resolve many of these invalid usages.\n"
+  comment: |
+    This recipe is designed to match on broken code as part of an overall migration from Joda-Time to java.time.
+
+    The Instant and DateTimeZone arguments provided to this constructor will be required to be migrated to complete this migration.
+    This can be done before or after the migration of this constructor. This recipe detects both Joda-Time and java.time types for each argument 1 to allow this behaviour.
+
+    This recipe will cause broken code as part of an overall number of steps to perform a migration of Joda-Time to java.time.
+
+    After migrating this instance creation to the java.time equivalent, subsequent method calls and usages of the instance may become invalid.
+    Further Sensei recipes are available to help resolve many of these invalid usages.
   descriptionFile: descriptions/datetime.html
   tags: framework specific;java.time;Joda-Time;quality
 search:

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-Instant-DateTimeZone.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-Instant-DateTimeZone.yaml
@@ -12,6 +12,8 @@ metadata:
     The Instant and DateTimeZone arguments provided to this constructor will be required to be migrated to complete this migration.
     This can be done before or after the migration of this constructor. This recipe detects both Joda-Time and java.time types for each argument 1 to allow this behaviour.
 
+    Additionally, the reason there are separate migration recipes for Instant and TemporalAccessor, is that even though java.time.Instant implements the java.time.temporal.TemporalAccessor interface, it cannot be used in ZonedDateTime.from(TemporalAccessor) or OffsetDateTime.from(TemporalAccessor) because a DateTimeException will be thrown, complaining it cannot determine the time zone.
+
     This recipe will cause broken code as part of an overall number of steps to perform a migration of Joda-Time to java.time.
 
     After migrating this instance creation to the java.time equivalent, subsequent method calls and usages of the instance may become invalid.

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-Instant-DateTimeZone.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-Instant-DateTimeZone.yaml
@@ -1,0 +1,37 @@
+id: scw:java.time:Joda-Time:DateTime-constructor-Instant-DateTimeZone
+version: 10
+metadata:
+  name: Migrate new DateTime(java.time.Instant, DateTimeZone) to java.time
+  shortDescription: Migrate new DateTime(java.time.Instant, DateTimeZone) to java.time
+  level: warning
+  language: java
+  enabled: true
+  comment: "This recipe is designed to match on broken code as part of an overall migration from Joda-Time to java.time.\n\nThe Instant and DateTimeZone arguments provided to this constructor will be required to be migrated to complete this migration. \nThis can be done before or after the migration of this constructor. This recipe detects both Joda-Time and java.time types for each argument 1 to allow this behaviour.\n\nThis recipe will cause broken code as part of an overall number of steps to perform a migration of Joda-Time to java.time.\n\nAfter migrating this instance creation to the java.time equivalent, subsequent method calls and usages of the instance may become invalid.\nFurther Sensei recipes are available to help resolve many of these invalid usages.\n"
+  descriptionFile: descriptions/datetime.html
+  tags: framework specific;java.time;Joda-Time;quality
+search:
+  instanceCreation:
+    args:
+      1:
+        anyOf:
+        - type: java.time.Instant
+        - type: org.joda.time.Instant
+      2:
+        anyOf:
+        - type: java.time.ZoneId
+        - type: org.joda.time.DateTimeZone
+    argCount: 2
+    type: org.joda.time.DateTime
+availableFixes:
+- name: Migrate to java.time.ZonedDateTime
+  actions:
+  - rewrite:
+      to: java.time.ZonedDateTime.ofInstant({{{ arguments.0 }}},{{{ arguments.1 }}})
+  - modifyAssignedVariable:
+      type: java.time.ZonedDateTime
+- name: Migrate to java.time.OffsetDateTime
+  actions:
+  - rewrite:
+      to: java.time.OffsetDateTime.ofInstant({{{ arguments.0 }}},{{{ arguments.1 }}})
+  - modifyAssignedVariable:
+      type: java.time.OffsetDateTime

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-Instant-DateTimeZone.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-Instant-DateTimeZone.yaml
@@ -12,6 +12,9 @@ metadata:
     The Instant and DateTimeZone arguments provided to this constructor will be required to be migrated to complete this migration.
     This can be done before or after the migration of this constructor. This recipe detects both Joda-Time and java.time types for each argument 1 to allow this behaviour.
 
+    It is worth noting this recipe uses ZoneId.of("UTC") and ZoneOffset.UTC instead of ZoneId.systemDefault() in the fixes.
+    The reason for this, is that in Joda-Time the new DateTime(Instant) constructor behaves differently to the other DateTime constructors, by using UTC as the Default DateTimeZone instead of the System Default.
+
     Additionally, the reason there are separate migration recipes for Instant and TemporalAccessor, is that even though java.time.Instant implements the java.time.temporal.TemporalAccessor interface, it cannot be used in ZonedDateTime.from(TemporalAccessor) or OffsetDateTime.from(TemporalAccessor) because a DateTimeException will be thrown, complaining it cannot determine the time zone.
 
     This recipe will cause broken code as part of an overall number of steps to perform a migration of Joda-Time to java.time.

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-Instant.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-Instant.yaml
@@ -1,0 +1,33 @@
+id: scw:java.time:Joda-Time:DateTime-constructor-Instant
+version: 10
+metadata:
+  name: Migrate new DateTime(java.time.Instant) to java.time
+  shortDescription: Migrate new DateTime(java.time.Instant) to java.time
+  level: warning
+  language: java
+  enabled: true
+  comment: "This recipe is designed to match on broken code as part of an overall migration from Joda-Time to java.time.\nThe Instant argument provided to this constructor will be required to be migrated to complete this migration. \nThis can be done before or after the migration of this constructor. This recipe detects both types for argument 1 to allow this behaviour.\n\nThis recipe will cause broken code as part of an overall number of steps to perform a migration of Joda-Time to java.time.\n\nAfter migrating this instance creation to the java.time equivalent, subsequent method calls and usages of the instance may become invalid.\nFurther Sensei recipes are available to help resolve many of these invalid usages.\n"
+  descriptionFile: descriptions/datetime.html
+  tags: framework specific;java.time;Joda-Time;quality
+search:
+  instanceCreation:
+    args:
+      1:
+        anyOf:
+        - type: java.time.Instant
+        - type: org.joda.time.Instant
+    argCount: 1
+    type: org.joda.time.DateTime
+availableFixes:
+- name: Migrate to java.time.ZonedDateTime
+  actions:
+  - rewrite:
+      to: java.time.ZonedDateTime.ofInstant({{{ arguments.0 }}},java.time.ZoneId.of("UTC"))
+  - modifyAssignedVariable:
+      type: java.time.ZonedDateTime
+- name: Migrate to java.time.OffsetDateTime
+  actions:
+  - rewrite:
+      to: java.time.OffsetDateTime.ofInstant({{{ arguments.0 }}},java.time.ZoneOffset.UTC)
+  - modifyAssignedVariable:
+      type: java.time.OffsetDateTime

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-Instant.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-Instant.yaml
@@ -8,8 +8,12 @@ metadata:
   enabled: true
   comment: |
     This recipe is designed to match on broken code as part of an overall migration from Joda-Time to java.time.
+
     The Instant argument provided to this constructor will be required to be migrated to complete this migration.
     This can be done before or after the migration of this constructor. This recipe detects both types for argument 1 to allow this behaviour.
+
+    It is worth noting this recipe uses ZoneId.of("UTC") and ZoneOffset.UTC instead of ZoneId.systemDefault() in the fixes.
+    The reason for this, is that in Joda-Time the new DateTime(Instant) constructor behaves differently to the other DateTime constructors, by using UTC as the Default DateTimeZone instead of the System Default.
 
     Additionally, the reason there are separate migration recipes for Instant and TemporalAccessor, is that even though java.time.Instant implements the java.time.temporal.TemporalAccessor interface, it cannot be used in ZonedDateTime.from(TemporalAccessor) or OffsetDateTime.from(TemporalAccessor) because a DateTimeException will be thrown, complaining it cannot determine the time zone.
 

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-Instant.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-Instant.yaml
@@ -6,7 +6,15 @@ metadata:
   level: warning
   language: java
   enabled: true
-  comment: "This recipe is designed to match on broken code as part of an overall migration from Joda-Time to java.time.\nThe Instant argument provided to this constructor will be required to be migrated to complete this migration. \nThis can be done before or after the migration of this constructor. This recipe detects both types for argument 1 to allow this behaviour.\n\nThis recipe will cause broken code as part of an overall number of steps to perform a migration of Joda-Time to java.time.\n\nAfter migrating this instance creation to the java.time equivalent, subsequent method calls and usages of the instance may become invalid.\nFurther Sensei recipes are available to help resolve many of these invalid usages.\n"
+  comment: |
+    This recipe is designed to match on broken code as part of an overall migration from Joda-Time to java.time.
+    The Instant argument provided to this constructor will be required to be migrated to complete this migration.
+    This can be done before or after the migration of this constructor. This recipe detects both types for argument 1 to allow this behaviour.
+
+    This recipe will cause broken code as part of an overall number of steps to perform a migration of Joda-Time to java.time.
+
+    After migrating this instance creation to the java.time equivalent, subsequent method calls and usages of the instance may become invalid.
+    Further Sensei recipes are available to help resolve many of these invalid usages.
   descriptionFile: descriptions/datetime.html
   tags: framework specific;java.time;Joda-Time;quality
 search:

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-Instant.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-Instant.yaml
@@ -11,6 +11,8 @@ metadata:
     The Instant argument provided to this constructor will be required to be migrated to complete this migration.
     This can be done before or after the migration of this constructor. This recipe detects both types for argument 1 to allow this behaviour.
 
+    Additionally, the reason there are separate migration recipes for Instant and TemporalAccessor, is that even though java.time.Instant implements the java.time.temporal.TemporalAccessor interface, it cannot be used in ZonedDateTime.from(TemporalAccessor) or OffsetDateTime.from(TemporalAccessor) because a DateTimeException will be thrown, complaining it cannot determine the time zone.
+
     This recipe will cause broken code as part of an overall number of steps to perform a migration of Joda-Time to java.time.
 
     After migrating this instance creation to the java.time equivalent, subsequent method calls and usages of the instance may become invalid.

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-Object-DateTimeZone.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-Object-DateTimeZone.yaml
@@ -6,7 +6,13 @@ metadata:
   level: info
   language: java
   enabled: true
-  comment: "Joda-Time provided a new DateTime(Object, DateTimeZone) constructor, which would accept any type of Object.\nWithin the constructor, it would look up a list of converters to assist in converting this object to a DateTime.\nAdditionally the converter list was configurable, so you could indeed write your own converter which might convert an object from your own problem domain into a DateTime\n\nIn java.time, this converter mechanism no longer exists. \nThe equivalent method ZonedDateTime.from(TemporalAccessor temporal) expects the object to implement the TemporalAccessor."
+  comment: |
+    Joda-Time provided a new DateTime(Object, DateTimeZone) constructor, which would accept any type of Object.
+    Within the constructor, it would look up a list of converters to assist in converting this object to a DateTime.
+    Additionally the converter list was configurable, so you could indeed write your own converter which might convert an object from your own problem domain into a DateTime
+
+    In java.time, this converter mechanism no longer exists.
+    The equivalent method ZonedDateTime.from(TemporalAccessor temporal) expects the object to implement the TemporalAccessor.
   descriptionFile: descriptions/datetime.html
   tags: framework specific;java.time;Joda-Time;quality
 search:

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-Object-DateTimeZone.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-Object-DateTimeZone.yaml
@@ -1,0 +1,33 @@
+id: scw:java.time:Joda-Time:DateTime-constructor-Object-DateTimeZone
+version: 10
+metadata:
+  name: Constructor argument (Object) needs to be migrated to java.time before Constructor Migration can occur
+  shortDescription: Constructor argument (Object) needs to be migrated to java.time before Constructor Migration can occur
+  level: info
+  language: java
+  enabled: true
+  comment: "Joda-Time provided a new DateTime(Object, DateTimeZone) constructor, which would accept any type of Object.\nWithin the constructor, it would look up a list of converters to assist in converting this object to a DateTime.\nAdditionally the converter list was configurable, so you could indeed write your own converter which might convert an object from your own problem domain into a DateTime\n\nIn java.time, this converter mechanism no longer exists. \nThe equivalent method ZonedDateTime.from(TemporalAccessor temporal) expects the object to implement the TemporalAccessor."
+  descriptionFile: descriptions/datetime.html
+  tags: framework specific;java.time;Joda-Time;quality
+search:
+  instanceCreation:
+    args:
+      1:
+        not:
+          anyOf:
+          - type: long
+          - type: java.lang.Long
+          - type: int
+          - type: java.lang.Integer
+          - type: java.util.Calendar
+          - type: java.util.Date
+          - type: java.lang.String
+          - type: java.time.temporal.TemporalAccessor
+          - type: org.joda.time.ReadableInstant
+      2:
+        anyOf:
+        - type: java.time.ZoneId
+        - type: org.joda.time.DateTimeZone
+    argCount: 2
+    type: org.joda.time.DateTime
+availableFixes: []

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-Object.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-Object.yaml
@@ -1,0 +1,29 @@
+id: scw:java.time:Joda-Time:DateTime-constructor-Object
+version: 10
+metadata:
+  name: Constructor argument (Object) needs to be migrated to java.time before Constructor Migration can occur
+  shortDescription: Constructor argument (Object) needs to be migrated to java.time before Constructor Migration can occur
+  level: info
+  language: java
+  enabled: true
+  comment: "Joda-Time provided a new DateTime(Object, DateTimeZone) constructor, which would accept any type of Object.\nWithin the constructor, it would look up a list of converters to assist in converting this object to a DateTime.\nAdditionally the converter list was configurable, so you could indeed write your own converter which might convert an object from your own problem domain into a DateTime\n\nIn java.time, this converter mechanism no longer exists. \nThe equivalent method ZonedDateTime.from(TemporalAccessor temporal) expects the object to implement the TemporalAccessor."
+  descriptionFile: descriptions/datetime.html
+  tags: framework specific;java.time;Joda-Time;quality
+search:
+  instanceCreation:
+    args:
+      1:
+        not:
+          anyOf:
+          - type: long
+          - type: java.lang.Long
+          - type: int
+          - type: java.lang.Integer
+          - type: java.util.Calendar
+          - type: java.util.Date
+          - type: java.lang.String
+          - type: java.time.temporal.TemporalAccessor
+          - type: org.joda.time.ReadableInstant
+    argCount: 1
+    type: org.joda.time.DateTime
+availableFixes: []

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-Object.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-Object.yaml
@@ -6,7 +6,13 @@ metadata:
   level: info
   language: java
   enabled: true
-  comment: "Joda-Time provided a new DateTime(Object, DateTimeZone) constructor, which would accept any type of Object.\nWithin the constructor, it would look up a list of converters to assist in converting this object to a DateTime.\nAdditionally the converter list was configurable, so you could indeed write your own converter which might convert an object from your own problem domain into a DateTime\n\nIn java.time, this converter mechanism no longer exists. \nThe equivalent method ZonedDateTime.from(TemporalAccessor temporal) expects the object to implement the TemporalAccessor."
+  comment: |
+    Joda-Time provided a new DateTime(Object, DateTimeZone) constructor, which would accept any type of Object.
+    Within the constructor, it would look up a list of converters to assist in converting this object to a DateTime.
+    Additionally the converter list was configurable, so you could indeed write your own converter which might convert an object from your own problem domain into a DateTime.
+
+    In java.time, this converter mechanism no longer exists.
+    The equivalent method ZonedDateTime.from(TemporalAccessor temporal) expects the object to implement the TemporalAccessor.
   descriptionFile: descriptions/datetime.html
   tags: framework specific;java.time;Joda-Time;quality
 search:

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-ReadableInstant.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-ReadableInstant.yaml
@@ -1,0 +1,27 @@
+id: scw:java.time:Joda-Time:DateTime-constructor-ReadableInstant
+version: 10
+metadata:
+  name: Constructor argument (ReadableInstant) needs to be migrated to java.time before Constructor Migration can occur
+  shortDescription: Constructor argument (ReadableInstant) needs to be migrated to java.time before Constructor Migration can occur
+  level: info
+  language: java
+  enabled: true
+  comment: |
+    Searches for an instance creation of org.joda.time.DateTime and provides fixes to migrate to a java.time equivalent.
+
+    This recipe will cause broken code as part of an overall number of steps to perform a migration of Joda-Time to java.time.
+
+    After migrating this instance creation to the java.time equivalent, subsequent method calls and usages of the instance may become invalid.
+    Further Sensei recipes are available to help resolve many of these invalid usages.
+  descriptionFile: descriptions/datetime.html
+  tags: framework specific;java.time;Joda-Time;quality
+search:
+  instanceCreation:
+    args:
+      1:
+        type: org.joda.time.ReadableInstant
+    anyOf:
+    - argCount: 1
+    - argCount: 2
+    type: org.joda.time.DateTime
+availableFixes: []

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-ReadableInstant.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-ReadableInstant.yaml
@@ -7,12 +7,10 @@ metadata:
   language: java
   enabled: true
   comment: |
-    Searches for an instance creation of org.joda.time.DateTime and provides fixes to migrate to a java.time equivalent.
+    Searches for an instance creation of org.joda.time.DateTime which uses a ReadableInstant as an argument to the constructor.
 
-    This recipe will cause broken code as part of an overall number of steps to perform a migration of Joda-Time to java.time.
-
-    After migrating this instance creation to the java.time equivalent, subsequent method calls and usages of the instance may become invalid.
-    Further Sensei recipes are available to help resolve many of these invalid usages.
+    This recipe is an information only recipe, to guide the user to migrate the ReadableInstant to a java.time equivalent first.
+    After migrating the ReadableInstant argument, this recipe will no longer match, and new recipes that provide the migration fixes will be able to match, depending on which java.time class the ReadableInstant was migrated to (ZonedDateTime, OffsetDateTime or Instant).
   descriptionFile: descriptions/datetime.html
   tags: framework specific;java.time;Joda-Time;quality
 search:

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-TemporalAccessor-DateTimeZone.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-TemporalAccessor-DateTimeZone.yaml
@@ -1,0 +1,40 @@
+id: scw:java.time:Joda-Time:DateTime-constructor-TemporalAccessor-DateTimeZone
+version: 10
+metadata:
+  name: Migrate new DateTime(java.time.TemporalAccessor, DateTimeZone) to java.time
+  shortDescription: Migrate new DateTime(java.time.TemporalAccessor, DateTimeZone) to java.time
+  level: warning
+  language: java
+  enabled: true
+  comment: |
+    This recipe is designed to match on broken code as part of an overall migration from Joda-Time to java.time.
+
+    In Joda-Time the DateTime class has a constructor which simply accepts an Object, and during construction the class would figure out what type of object it was and construct the DateTime appropriately.
+    One of the classes that can be detected is ReadableInstant. When migrating a new DateTime(ReadableInstant) call, you must first migrate the Joda-Time ReadableInstant argument to the java.time equivalent.
+
+    This recipe will cause broken code as part of an overall number of steps to perform a migration of Joda-Time to java.time.
+
+    After migrating this instance creation to the java.time equivalent, subsequent method calls and usages of the instance may become invalid.
+    Further Sensei recipes are available to help resolve many of these invalid usages.
+  descriptionFile: descriptions/datetime.html
+  tags: framework specific;java.time;Joda-Time;quality
+search:
+  instanceCreation:
+    args:
+      1:
+        not:
+          type: java.time.Instant
+        type: java.time.temporal.TemporalAccessor
+      2:
+        anyOf:
+        - type: java.time.ZoneId
+        - type: org.joda.time.DateTimeZone
+    argCount: 2
+    type: org.joda.time.DateTime
+availableFixes:
+- name: Migrate to java.time.ZonedDateTime
+  actions:
+  - rewrite:
+      to: java.time.ZonedDateTime.from({{{ arguments.0 }}}).withZoneSameInstant({{{ arguments.1 }}})
+  - modifyAssignedVariable:
+      type: java.time.ZonedDateTime

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-TemporalAccessor-DateTimeZone.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-TemporalAccessor-DateTimeZone.yaml
@@ -12,6 +12,8 @@ metadata:
     In Joda-Time the DateTime class has a constructor which simply accepts an Object, and during construction the class would figure out what type of object it was and construct the DateTime appropriately.
     One of the classes that can be detected is ReadableInstant. When migrating a new DateTime(ReadableInstant) call, you must first migrate the Joda-Time ReadableInstant argument to the java.time equivalent.
 
+    This recipe explicitly excludes java.time.Instant, even though a java.time.Instant implements the java.time.temporal.TemporalAccessor interface. The reason for this is that java.time.Instant cannot be used with the ZonedDateTime.from(TemporalAccessor) and OffsetDateTime.from(TemporalAccessor) factory methods. A DateTimeException will be thrown when an Instant is passed to these methods, because the time zone or offset cannot be determined from the Instant. For this reason, there are separate migration recipes for Instant which migrate to ZonedDateTime.ofInstant(Instant, ZoneId) and OffsetDateTime.ofInstant(Instant, ZoneId) instead.
+
     This recipe will cause broken code as part of an overall number of steps to perform a migration of Joda-Time to java.time.
 
     After migrating this instance creation to the java.time equivalent, subsequent method calls and usages of the instance may become invalid.

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-TemporalAccessor.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-TemporalAccessor.yaml
@@ -1,0 +1,42 @@
+id: scw:java.time:Joda-Time:DateTime-constructor-TemporalAccessor
+version: 10
+metadata:
+  name: Migrate new DateTime(java.time.TemporalAccessor) to java.time
+  shortDescription: Migrate new DateTime(java.time.TemporalAccessor) to java.time
+  level: warning
+  language: java
+  enabled: true
+  comment: |
+    This recipe is designed to match on broken code as part of an overall migration from Joda-Time to java.time.
+
+    In Joda-Time the DateTime class has a constructor which simply accepts an Object, and during construction the class would figure out what type of object it was and construct the DateTime appropriately.
+    One of the classes that can be detected is ReadableInstant. When migrating a new DateTime(ReadableInstant) call, you must first migrate the Joda-Time ReadableInstant argument to the java.time equivalent.
+
+    This recipe will cause broken code as part of an overall number of steps to perform a migration of Joda-Time to java.time.
+
+    After migrating this instance creation to the java.time equivalent, subsequent method calls and usages of the instance may become invalid.
+    Further Sensei recipes are available to help resolve many of these invalid usages.
+  descriptionFile: descriptions/datetime.html
+  tags: framework specific;java.time;Joda-Time;quality
+search:
+  instanceCreation:
+    args:
+      1:
+        not:
+          type: java.time.Instant
+        type: java.time.temporal.TemporalAccessor
+    argCount: 1
+    type: org.joda.time.DateTime
+availableFixes:
+- name: Migrate to java.time.ZonedDateTime
+  actions:
+  - rewrite:
+      to: java.time.ZonedDateTime.from({{{ arguments.0 }}})
+  - modifyAssignedVariable:
+      type: java.time.ZonedDateTime
+- name: Migrate to java.time.OffsetDateTime
+  actions:
+  - rewrite:
+      to: java.time.OffsetDateTime.from({{{ arguments.0 }}})
+  - modifyAssignedVariable:
+      type: java.time.OffsetDateTime

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-TemporalAccessor.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-TemporalAccessor.yaml
@@ -12,6 +12,8 @@ metadata:
     In Joda-Time the DateTime class has a constructor which simply accepts an Object, and during construction the class would figure out what type of object it was and construct the DateTime appropriately.
     One of the classes that can be detected is ReadableInstant. When migrating a new DateTime(ReadableInstant) call, you must first migrate the Joda-Time ReadableInstant argument to the java.time equivalent.
 
+    This recipe explicitly excludes java.time.Instant, even though a java.time.Instant implements the java.time.temporal.TemporalAccessor interface. The reason for this is that java.time.Instant cannot be used with the ZonedDateTime.from(TemporalAccessor) and OffsetDateTime.from(TemporalAccessor) factory methods. A DateTimeException will be thrown when an Instant is passed to these methods, because the time zone or offset cannot be determined from the Instant. For this reason, there are separate migration recipes for Instant which migrate to ZonedDateTime.ofInstant(Instant, ZoneId) and OffsetDateTime.ofInstant(Instant, ZoneId) instead.
+
     This recipe will cause broken code as part of an overall number of steps to perform a migration of Joda-Time to java.time.
 
     After migrating this instance creation to the java.time equivalent, subsequent method calls and usages of the instance may become invalid.

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-empty.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-empty.yaml
@@ -1,0 +1,34 @@
+id: scw:java.time:Joda-Time:DateTime-constructor-empty
+version: 10
+metadata:
+  name: Migrate new DateTime() to java.time
+  shortDescription: Migrate new DateTime() to java.time
+  level: warning
+  language: java
+  enabled: true
+  comment: |
+    Searches for an instance creation of org.joda.time.DateTime and provides fixes to migrate to a java.time equivalent.
+
+    This recipe will cause broken code as part of an overall number of steps to perform a migration of Joda-Time to java.time.
+
+    After migrating this instance creation to the java.time equivalent, subsequent method calls and usages of the instance may become invalid.
+    Further Sensei recipes are available to help resolve many of these invalid usages.
+  descriptionFile: descriptions/datetime.html
+  tags: framework specific;java.time;Joda-Time;quality
+search:
+  instanceCreation:
+    argCount: 0
+    type: org.joda.time.DateTime
+availableFixes:
+- name: Migrate to java.time.ZonedDateTime.now()
+  actions:
+  - modifyAssignedVariable:
+      type: java.time.ZonedDateTime
+  - rewrite:
+      to: java.time.ZonedDateTime.now()
+- name: Migrate to java.time.OffsetDateTime.now()
+  actions:
+  - modifyAssignedVariable:
+      type: java.time.OffsetDateTime
+  - rewrite:
+      to: java.time.OffsetDateTime.now()

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-long-DateTimeZone.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-long-DateTimeZone.yaml
@@ -1,0 +1,48 @@
+id: scw:java.time:Joda-Time:DateTime-constructor-long-DateTimeZone
+version: 10
+metadata:
+  name: Migrate new DateTime(long, DateTimeZone) to java.time
+  shortDescription: Migrate new DateTime(long, DateTimeZone) to java.time
+  level: warning
+  language: java
+  enabled: true
+  comment: |
+    Searches for an instance creation of org.joda.time.DateTime and provides fixes to migrate to a java.time equivalent.
+
+    This recipe is designed to match on broken code. The constructor originally accepts an org.joda.time.DateTimeZone argument, however this argument
+    should first be migrated to java.time.ZoneId using the DateTimeZone migration recipes.
+    This recipe will then match on the broken code, and the fixes in this recipe will allow the completion of the migration.
+
+    This recipe will cause broken code as part of an overall number of steps to perform a migration of Joda-Time to java.time.
+    After migrating this instance creation to the java.time equivalent, subsequent method calls and usages of the instance may become invalid.
+    Further Sensei recipes are available to help resolve many of these invalid usages.
+  descriptionFile: descriptions/datetime.html
+  tags: framework specific;java.time;Joda-Time;quality
+search:
+  instanceCreation:
+    args:
+      1:
+        anyOf:
+        - type: long
+        - type: java.lang.Long
+        - type: int
+        - type: java.lang.Integer
+      2:
+        anyOf:
+        - type: java.time.ZoneId
+        - type: org.joda.time.DateTimeZone
+    argCount: 2
+    type: org.joda.time.DateTime
+availableFixes:
+- name: Migrate to java.time ZonedDateTime
+  actions:
+  - rewrite:
+      to: java.time.ZonedDateTime.ofInstant(java.time.Instant.ofEpochMilli({{{ arguments.0 }}}), {{{ arguments.1 }}})
+  - modifyAssignedVariable:
+      type: java.time.ZonedDateTime
+- name: Migrate to java.time.OffsetDateTime
+  actions:
+  - rewrite:
+      to: java.time.OffsetDateTime.ofInstant(java.time.Instant.ofEpochMilli({{{ arguments.0 }}}), {{{ arguments.1 }}})
+  - modifyAssignedVariable:
+      type: java.time.OffsetDateTime

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-long.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-long.yaml
@@ -1,0 +1,41 @@
+id: scw:java.time:Joda-Time:DateTime-constructor-long
+version: 10
+metadata:
+  name: Migrate new DateTime(long) to java.time
+  shortDescription: Migrate new DateTime(long) to java.time
+  level: warning
+  language: java
+  enabled: true
+  comment: |
+    Searches for an instance creation of org.joda.time.DateTime and provides fixes to migrate to a java.time equivalent.
+
+    This recipe will cause broken code as part of an overall number of steps to perform a migration of Joda-Time to java.time.
+
+    After migrating this instance creation to the java.time equivalent, subsequent method calls and usages of the instance may become invalid.
+    Further Sensei recipes are available to help resolve many of these invalid usages.
+  descriptionFile: descriptions/datetime.html
+  tags: framework specific;java.time;Joda-Time;quality
+search:
+  instanceCreation:
+    args:
+      1:
+        anyOf:
+        - type: long
+        - type: java.lang.Long
+        - type: int
+        - type: java.lang.Integer
+    argCount: 1
+    type: org.joda.time.DateTime
+availableFixes:
+- name: Migrate to java.time ZonedDateTime
+  actions:
+  - rewrite:
+      to: java.time.ZonedDateTime.ofInstant(java.time.Instant.ofEpochMilli({{{ arguments.0 }}}), java.time.ZoneId.systemDefault())
+  - modifyAssignedVariable:
+      type: java.time.ZonedDateTime
+- name: Migrate to java.time OffsetDateTime
+  actions:
+  - rewrite:
+      to: java.time.OffsetDateTime.ofInstant(java.time.Instant.ofEpochMilli({{{ arguments.0 }}}), java.time.ZoneId.systemDefault())
+  - modifyAssignedVariable:
+      type: java.time.OffsetDateTime

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-year-month-day-hour-minute-DateTimeZone.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-year-month-day-hour-minute-DateTimeZone.yaml
@@ -1,0 +1,54 @@
+id: scw:java.time:Joda-Time:DateTime-constructor-year-month-day-hour-minute-DateTimeZone
+version: 10
+metadata:
+  name: Migrate new DateTime(year, month, day, hour, minute, DateTimeZone) to java.time
+  shortDescription: Migrate new DateTime(year, month, day, hour, minute, DateTimeZone) to java.time
+  level: warning
+  language: java
+  enabled: true
+  comment: |+
+    Searches for an instance creation of org.joda.time.DateTime and provides fixes to migrate to a java.time equivalent.
+
+    This recipe is designed to match on broken code. The constructor originally accepts an org.joda.time.DateTimeZone argument, however this argument
+    should first be migrated to java.time.ZoneId using the DateTimeZone migration recipes.
+    This recipe will then match on the broken code, and the fixes in this recipe will allow the completion of the migration.
+
+    This recipe will cause broken code as part of an overall number of steps to perform a migration of Joda-Time to java.time.
+    After migrating this instance creation to the java.time equivalent, subsequent method calls and usages of the instance may become invalid.
+    Further Sensei recipes are available to help resolve many of these invalid usages.
+
+  descriptionFile: descriptions/datetime.html
+  tags: framework specific;java.time;Joda-Time;quality
+search:
+  instanceCreation:
+    args:
+      1:
+        anyOf:
+        - type: int
+        - type: java.lang.Integer
+      2:
+        anyOf:
+        - type: int
+        - type: java.lang.Integer
+      3:
+        anyOf:
+        - type: int
+        - type: java.lang.Integer
+      4:
+        anyOf:
+        - type: int
+        - type: java.lang.Integer
+      5:
+        anyOf:
+        - type: int
+        - type: java.lang.Integer
+      6:
+        type: java.time.ZoneId
+    type: org.joda.time.DateTime
+availableFixes:
+- name: Migrate to java.time.ZonedDateTime
+  actions:
+  - rewrite:
+      to: java.time.ZonedDateTime.of({{{ arguments.0 }}}, {{{ arguments.1 }}}, {{{ arguments.2 }}}, {{{ arguments.3 }}}, {{{ arguments.4 }}}, 0, 0, {{{ arguments.5 }}})
+  - modifyAssignedVariable:
+      type: java.time.ZonedDateTime

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-year-month-day-hour-minute-DateTimeZone.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-year-month-day-hour-minute-DateTimeZone.yaml
@@ -6,7 +6,7 @@ metadata:
   level: warning
   language: java
   enabled: true
-  comment: |+
+  comment: |
     Searches for an instance creation of org.joda.time.DateTime and provides fixes to migrate to a java.time equivalent.
 
     This recipe is designed to match on broken code. The constructor originally accepts an org.joda.time.DateTimeZone argument, however this argument
@@ -16,7 +16,6 @@ metadata:
     This recipe will cause broken code as part of an overall number of steps to perform a migration of Joda-Time to java.time.
     After migrating this instance creation to the java.time equivalent, subsequent method calls and usages of the instance may become invalid.
     Further Sensei recipes are available to help resolve many of these invalid usages.
-
   descriptionFile: descriptions/datetime.html
   tags: framework specific;java.time;Joda-Time;quality
 search:

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-year-month-day-hour-minute-second-DateTimeZone.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-year-month-day-hour-minute-second-DateTimeZone.yaml
@@ -6,7 +6,7 @@ metadata:
   level: warning
   language: java
   enabled: true
-  comment: |+
+  comment: |
     Searches for an instance creation of org.joda.time.DateTime and provides fixes to migrate to a java.time equivalent.
 
     This recipe is designed to match on broken code. The constructor originally accepts an org.joda.time.DateTimeZone argument, however this argument
@@ -16,7 +16,6 @@ metadata:
     This recipe will cause broken code as part of an overall number of steps to perform a migration of Joda-Time to java.time.
     After migrating this instance creation to the java.time equivalent, subsequent method calls and usages of the instance may become invalid.
     Further Sensei recipes are available to help resolve many of these invalid usages.
-
   descriptionFile: descriptions/datetime.html
   tags: framework specific;java.time;Joda-Time;quality
 search:

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-year-month-day-hour-minute-second-DateTimeZone.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-year-month-day-hour-minute-second-DateTimeZone.yaml
@@ -1,0 +1,58 @@
+id: scw:java.time:Joda-Time:DateTime-constructor-year-month-day-hour-minute-second-DateTimeZone
+version: 10
+metadata:
+  name: Migrate new DateTime(year, month, day, hour, minute, second, DateTimeZone) to java.time
+  shortDescription: Migrate new DateTime(year, month, day, hour, minute, second, DateTimeZone) to java.time
+  level: warning
+  language: java
+  enabled: true
+  comment: |+
+    Searches for an instance creation of org.joda.time.DateTime and provides fixes to migrate to a java.time equivalent.
+
+    This recipe is designed to match on broken code. The constructor originally accepts an org.joda.time.DateTimeZone argument, however this argument
+    should first be migrated to java.time.ZoneId using the DateTimeZone migration recipes.
+    This recipe will then match on the broken code, and the fixes in this recipe will allow the completion of the migration.
+
+    This recipe will cause broken code as part of an overall number of steps to perform a migration of Joda-Time to java.time.
+    After migrating this instance creation to the java.time equivalent, subsequent method calls and usages of the instance may become invalid.
+    Further Sensei recipes are available to help resolve many of these invalid usages.
+
+  descriptionFile: descriptions/datetime.html
+  tags: framework specific;java.time;Joda-Time;quality
+search:
+  instanceCreation:
+    args:
+      1:
+        anyOf:
+        - type: int
+        - type: java.lang.Integer
+      2:
+        anyOf:
+        - type: int
+        - type: java.lang.Integer
+      3:
+        anyOf:
+        - type: int
+        - type: java.lang.Integer
+      4:
+        anyOf:
+        - type: int
+        - type: java.lang.Integer
+      5:
+        anyOf:
+        - type: int
+        - type: java.lang.Integer
+      6:
+        anyOf:
+        - type: int
+        - type: java.lang.Integer
+      7:
+        type: java.time.ZoneId
+    type: org.joda.time.DateTime
+availableFixes:
+- name: Migrate to java.time.ZonedDateTime
+  actions:
+  - rewrite:
+      to: java.time.ZonedDateTime.of({{{ arguments.0 }}}, {{{ arguments.1 }}}, {{{ arguments.2 }}}, {{{ arguments.3 }}}, {{{ arguments.4 }}}, {{{ arguments.5 }}}, 0, {{{ arguments.6 }}})
+  - modifyAssignedVariable:
+      type: java.time.ZonedDateTime

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-year-month-day-hour-minute-second-millis-DateTimeZone.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-year-month-day-hour-minute-second-millis-DateTimeZone.yaml
@@ -1,0 +1,63 @@
+id: scw:java.time:Joda-Time:DateTime-constructor-year-month-day-hour-minute-second-millis-DateTimeZone
+version: 10
+metadata:
+  name: Migrate new DateTime(year, month, day, hour, minute, second, millis, DateTimeZone) to java.time
+  shortDescription: Migrate new DateTime(year, month, day, hour, minute, second, millis, DateTimeZone) to java.time
+  level: warning
+  language: java
+  enabled: true
+  comment: |+
+    Searches for an instance creation of org.joda.time.DateTime and provides fixes to migrate to a java.time equivalent.
+
+    This recipe is designed to match on broken code. The constructor originally accepts an org.joda.time.DateTimeZone argument, however this argument
+    should first be migrated to java.time.ZoneId using the DateTimeZone migration recipes.
+    This recipe will then match on the broken code, and the fixes in this recipe will allow the completion of the migration.
+
+    This recipe will cause broken code as part of an overall number of steps to perform a migration of Joda-Time to java.time.
+    After migrating this instance creation to the java.time equivalent, subsequent method calls and usages of the instance may become invalid.
+    Further Sensei recipes are available to help resolve many of these invalid usages.
+
+  descriptionFile: descriptions/datetime.html
+  tags: framework specific;java.time;Joda-Time;quality
+search:
+  instanceCreation:
+    args:
+      1:
+        anyOf:
+        - type: int
+        - type: java.lang.Integer
+      2:
+        anyOf:
+        - type: int
+        - type: java.lang.Integer
+      3:
+        anyOf:
+        - type: int
+        - type: java.lang.Integer
+      4:
+        anyOf:
+        - type: int
+        - type: java.lang.Integer
+      5:
+        anyOf:
+        - type: int
+        - type: java.lang.Integer
+      6:
+        anyOf:
+        - type: int
+        - type: java.lang.Integer
+      7:
+        anyOf:
+        - type: int
+        - type: java.lang.Integer
+      8:
+        type: java.time.ZoneId
+    type: org.joda.time.DateTime
+availableFixes:
+- name: Migrate to java.time.ZonedDateTime
+  actions:
+  - rewrite:
+      to: java.time.ZonedDateTime.of({{{ arguments.0 }}}, {{{ arguments.1 }}}, {{{ arguments.2 }}}, {{{ arguments.3 }}}, {{{ arguments.4 }}}, {{{ arguments.5 }}}, 0, {{{ arguments.7 }}}).with(java.time.temporal.ChronoField.MILLI_OF_SECOND, {{{ arguments.6 }}})
+      target: self
+  - modifyAssignedVariable:
+      type: java.time.ZonedDateTime

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-year-month-day-hour-minute-second-millis-DateTimeZone.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-year-month-day-hour-minute-second-millis-DateTimeZone.yaml
@@ -6,7 +6,7 @@ metadata:
   level: warning
   language: java
   enabled: true
-  comment: |+
+  comment: |
     Searches for an instance creation of org.joda.time.DateTime and provides fixes to migrate to a java.time equivalent.
 
     This recipe is designed to match on broken code. The constructor originally accepts an org.joda.time.DateTimeZone argument, however this argument
@@ -16,7 +16,6 @@ metadata:
     This recipe will cause broken code as part of an overall number of steps to perform a migration of Joda-Time to java.time.
     After migrating this instance creation to the java.time equivalent, subsequent method calls and usages of the instance may become invalid.
     Further Sensei recipes are available to help resolve many of these invalid usages.
-
   descriptionFile: descriptions/datetime.html
   tags: framework specific;java.time;Joda-Time;quality
 search:

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-year-month-day-hour-minute-second-millis.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-year-month-day-hour-minute-second-millis.yaml
@@ -1,0 +1,58 @@
+id: scw:java.time:Joda-Time:DateTime-constructor-year-month-day-hour-minute-second-millis
+version: 10
+metadata:
+  name: Migrate new DateTime(year, month, day, hour, minute, second, millis) to java.time
+  shortDescription: Migrate new DateTime(year, month, day, hour, minute, second, millis) to java.time
+  level: warning
+  language: java
+  enabled: true
+  comment: |
+    Searches for an instance creation of org.joda.time.DateTime and provides fixes to migrate to a java.time equivalent.
+
+    This recipe will cause broken code as part of an overall number of steps to perform a migration of Joda-Time to java.time.
+
+    After migrating this instance creation to the java.time equivalent, subsequent method calls and usages of the instance may become invalid.
+    Further Sensei recipes are available to help resolve many of these invalid usages.
+  descriptionFile: descriptions/datetime.html
+  tags: framework specific;java.time;Joda-Time;quality
+search:
+  instanceCreation:
+    args:
+      1:
+        anyOf:
+        - type: int
+        - type: java.lang.Integer
+      2:
+        anyOf:
+        - type: int
+        - type: java.lang.Integer
+      3:
+        anyOf:
+        - type: int
+        - type: java.lang.Integer
+      4:
+        anyOf:
+        - type: int
+        - type: java.lang.Integer
+      5:
+        anyOf:
+        - type: int
+        - type: java.lang.Integer
+      6:
+        anyOf:
+        - type: int
+        - type: java.lang.Integer
+      7:
+        anyOf:
+        - type: int
+        - type: java.lang.Integer
+    argCount: 7
+    type: org.joda.time.DateTime
+availableFixes:
+- name: Migrate to java.time.ZonedDateTime
+  actions:
+  - rewrite:
+      to: java.time.ZonedDateTime.of({{{ arguments.0 }}}, {{{ arguments.1 }}}, {{{ arguments.2 }}}, {{{ arguments.3 }}}, {{{ arguments.4 }}}, {{{ arguments.5 }}}, 0, java.time.ZoneId.systemDefault()).with(java.time.temporal.ChronoField.MILLI_OF_SECOND, {{{ arguments.6 }}})
+      target: self
+  - modifyAssignedVariable:
+      type: java.time.ZonedDateTime

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-year-month-day-hour-minute-second.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-year-month-day-hour-minute-second.yaml
@@ -1,0 +1,53 @@
+id: scw:java.time:Joda-Time:DateTime-constructor-year-month-day-hour-minute-second
+version: 10
+metadata:
+  name: Migrate new DateTime(year, month, day, hour, minute, second) to java.time
+  shortDescription: Migrate new DateTime(year, month, day, hour, minute, second) to java.time
+  level: warning
+  language: java
+  enabled: true
+  comment: |
+    Searches for an instance creation of org.joda.time.DateTime and provides fixes to migrate to a java.time equivalent.
+
+    This recipe will cause broken code as part of an overall number of steps to perform a migration of Joda-Time to java.time.
+
+    After migrating this instance creation to the java.time equivalent, subsequent method calls and usages of the instance may become invalid.
+    Further Sensei recipes are available to help resolve many of these invalid usages.
+  descriptionFile: descriptions/datetime.html
+  tags: framework specific;java.time;Joda-Time;quality
+search:
+  instanceCreation:
+    args:
+      1:
+        anyOf:
+        - type: int
+        - type: java.lang.Integer
+      2:
+        anyOf:
+        - type: int
+        - type: java.lang.Integer
+      3:
+        anyOf:
+        - type: int
+        - type: java.lang.Integer
+      4:
+        anyOf:
+        - type: int
+        - type: java.lang.Integer
+      5:
+        anyOf:
+        - type: int
+        - type: java.lang.Integer
+      6:
+        anyOf:
+        - type: int
+        - type: java.lang.Integer
+    argCount: 6
+    type: org.joda.time.DateTime
+availableFixes:
+- name: Migrate to java.time.ZonedDateTime
+  actions:
+  - rewrite:
+      to: java.time.ZonedDateTime.of({{{ arguments.0 }}}, {{{ arguments.1 }}}, {{{ arguments.2 }}}, {{{ arguments.3 }}}, {{{ arguments.4 }}},{{{ arguments.5 }}}, 0, java.time.ZoneId.systemDefault())
+  - modifyAssignedVariable:
+      type: java.time.ZonedDateTime

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-year-month-day-hour-minute.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-constructor-year-month-day-hour-minute.yaml
@@ -1,0 +1,49 @@
+id: scw:java.time:Joda-Time:DateTime-constructor-year-month-day-hour-minute
+version: 10
+metadata:
+  name: Migrate new DateTime(year, month, day, hour, minute) to java.time
+  shortDescription: Migrate new DateTime(year, month, day, hour, minute) to java.time
+  level: warning
+  language: java
+  enabled: true
+  comment: |
+    Searches for an instance creation of org.joda.time.DateTime and provides fixes to migrate to a java.time equivalent.
+
+    This recipe will cause broken code as part of an overall number of steps to perform a migration of Joda-Time to java.time.
+
+    After migrating this instance creation to the java.time equivalent, subsequent method calls and usages of the instance may become invalid.
+    Further Sensei recipes are available to help resolve many of these invalid usages.
+  descriptionFile: descriptions/datetime.html
+  tags: framework specific;java.time;Joda-Time;quality
+search:
+  instanceCreation:
+    args:
+      1:
+        anyOf:
+        - type: int
+        - type: java.lang.Integer
+      2:
+        anyOf:
+        - type: int
+        - type: java.lang.Integer
+      3:
+        anyOf:
+        - type: int
+        - type: java.lang.Integer
+      4:
+        anyOf:
+        - type: int
+        - type: java.lang.Integer
+      5:
+        anyOf:
+        - type: int
+        - type: java.lang.Integer
+    argCount: 5
+    type: org.joda.time.DateTime
+availableFixes:
+- name: Migrate to java.time.ZonedDateTime
+  actions:
+  - rewrite:
+      to: java.time.ZonedDateTime.of({{{ arguments.0 }}}, {{{ arguments.1 }}}, {{{ arguments.2 }}}, {{{ arguments.3 }}}, {{{ arguments.4 }}}, 0, 0, java.time.ZoneId.systemDefault())
+  - modifyAssignedVariable:
+      type: java.time.ZonedDateTime

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/descriptions/datetime.html
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/descriptions/datetime.html
@@ -1,0 +1,27 @@
+<html>
+<body>
+<p id="abstract">Migrate from org.joda.time.DateTime to Java Time</p>
+<br>
+<p>Joda-Time DateTime migrates to java.time ZonedDateTime or OffsetDateTime.</p>
+<p>ZonedDateTime is the same concept, date and time with time-zone.</p>
+<p>OffsetDateTime is a new concept, date and time with offset from UTC.</p>
+<br>
+<b>Before</b>
+<pre>
+    DateTime dateTime = new DateTime();
+    int monthOfYear = dateTime.getMonthOfYear();
+</pre>
+<b>After</b>
+<pre>
+    ZonedDateTime dateTime = ZonedDateTime.now();
+    int monthOfYear = dateTime.getMonthValue();
+</pre>
+<br>
+<b>References</b>
+<ul>
+    <li><a href="https://docs.oracle.com/javase/8/docs/api/java/time/ZonedDateTime.html">ZonedDateTime (Java Platform SE 8 )</a></li>
+    <li><a href="https://docs.oracle.com/javase/8/docs/api/java/time/OffsetDateTime.html">OffsetDateTime (Java Platform SE 8 )</a></li>
+    <li><a href="https://blog.joda.org/2014/11/converting-from-joda-time-to-javatime.html">Converting from Joda-Time to java.time</a></li>
+</ul>
+</body>
+</html>


### PR DESCRIPTION
This pull request contains recipes for migration of org.joda.time.DateTime to java.time

The focus of this pull request is on recipes that are specific to DateTime migration.
These recipes do not cover all necessary cases for DateTime, there are some additional recipes that are common to DateTime and other Joda-Time classes, and those recipes will be submitted via a separate pull-request covering common recipes.

This pull request also does not contain the recipes for DateTime Constructors and Factory Methods which use a Chronology. The behaviour of Chronologies in java.time is different, I have some recipes that can achieve a similar result as Joda-Time but these need additional documentation and testing before submitting these recipes.

**Recipe Filenames:**
Recipe filenames have been named based on the original situation that is being migrated from, however the search may not be searching for that exact type. This is because the recipe may expect the arguments to be migrated to a new type before the recipe becomes active.
For example, there is a general constructor new Date(Object) which has many different migration paths depending on what the supplied object is. So there are multiple recipes for this constructor

Co-authored-by: Wander Neto <wneto@securecodewarrior.com>