### PR TITLE
SEN-2541 Recipes for migrating common 'get' methods for Joda-Time to java.time

### DIFF
--- a/example_code/joda-time-to-java-time-examples/joda-time-to-java-time-examples.iml
+++ b/example_code/joda-time-to-java-time-examples/joda-time-to-java-time-examples.iml
@@ -19,6 +19,6 @@
     <orderEntry type="library" scope="TEST" name="Maven: org.junit.platform:junit-platform-engine:1.7.2" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.junit.jupiter:junit-jupiter-params:5.7.2" level="project" />
     <orderEntry type="library" name="Maven: joda-time:joda-time:2.10.11" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.assertj:assertj-core:3.8.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.assertj:assertj-core:3.21.0" level="project" />
   </component>
 </module>

--- a/example_code/joda-time-to-java-time-examples/src/test/java/common/CommonGetMethodsTest.java
+++ b/example_code/joda-time-to-java-time-examples/src/test/java/common/CommonGetMethodsTest.java
@@ -1,0 +1,230 @@
+package common;
+
+import org.joda.time.*;
+import org.junit.jupiter.api.Test;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoField;
+import java.time.temporal.IsoFields;
+import java.time.temporal.WeekFields;
+import java.util.Locale;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CommonGetMethodsTest {
+
+    /*
+        This method is used to assert that the fix provided in getCenturyOfEra.yaml
+        will correctly determine the expected century of era
+     */
+    private void assertExpectedCenturyOfEra(int expectedCenturyOfEra, int javaYear) {
+
+        int centuryOfEra = Math.abs(javaYear / 100);
+        assertThat(centuryOfEra).isEqualTo(expectedCenturyOfEra);
+
+    }
+
+    /*
+        Test the algorithm used by the getCenturyOfEra recipe over a 10,000 year period
+     */
+    @Test
+    void getCenturyOfEra() {
+
+        IntStream.range(-11000, 11000).forEach(i -> test_CenturyOfEra_year(i));
+
+    }
+
+    /*
+        Test the algorithm used by the getYearOfCentury recipe over a 10,000 year period
+     */
+    @Test
+    void getYearOfCentury() {
+
+        IntStream.range(-11000, 11000).forEach(i -> test_yearOfCentury_year(i));
+
+    }
+
+    /*
+     * For a given year, tests that the Joda-Time method getCenturyOfEra() is equivalent to the algorithm used by
+     * the Common/get/getCenturyOfEra.yaml migration recipe
+     */
+    private void test_CenturyOfEra_year(int year) {
+
+        // DateTime
+        DateTime dt = DateTime.now().withYear(year);
+        DateMidnight dm = DateMidnight.now().withYear(year);
+        MutableDateTime mdt = MutableDateTime.now();
+        mdt.setYear(year);
+        ZonedDateTime zdt = ZonedDateTime.now().withYear(year);
+        assertExpectedCenturyOfEra(dt.getCenturyOfEra(), zdt.getYear());
+        assertExpectedCenturyOfEra(mdt.getCenturyOfEra(), zdt.getYear());
+        assertExpectedCenturyOfEra(dm.getCenturyOfEra(), zdt.getYear());
+
+        // Local Date
+        org.joda.time.LocalDate jodaLocalDate = org.joda.time.LocalDate.now().withYear(year);
+        java.time.LocalDate javaLocalDate = java.time.LocalDate.now().withYear(year);
+        assertExpectedCenturyOfEra(jodaLocalDate.getCenturyOfEra(), javaLocalDate.getYear());
+
+        // Local Date Time
+        org.joda.time.LocalDateTime jodaLocalDateTime = org.joda.time.LocalDateTime.now().withYear(year);
+        java.time.LocalDateTime javaLocalDateTime = java.time.LocalDateTime.now().withYear(year);
+        assertExpectedCenturyOfEra(jodaLocalDate.getCenturyOfEra(), javaLocalDate.getYear());
+
+
+    }
+
+
+    /*
+     * For a given year, tests that the Joda-Time method getYearOfCentury() is equivalent to the algorithm used by
+     * the Common/get/getYearOfCentury.yaml migration recipe
+     */
+    private void assertExpectedYearOfCentury(int expectedYearOfCentury, int year) {
+
+        int yearOfCentury = Math.abs(year % 100);
+        assertThat(yearOfCentury).isEqualTo(expectedYearOfCentury);
+
+
+    }
+
+    private void test_yearOfCentury_year(int year) {
+
+        DateTime dt = DateTime.now().withYear(year);
+        ZonedDateTime zdt = ZonedDateTime.now().withYear(year);
+
+        assertExpectedYearOfCentury(dt.getYearOfCentury(), zdt.getYear());
+
+    }
+
+    /*
+        This test supports the transformations used in Common/get/getChronoField.yaml
+     */
+    @Test
+    void getChronoField() {
+
+        LocalDate jodaLocalDate = LocalDate.now();
+        java.time.LocalDate javaLocalDate = java.time.LocalDate.now();
+
+        assertThat(javaLocalDate.get(ChronoField.ERA)).isEqualTo(jodaLocalDate.getEra());
+        assertThat(javaLocalDate.get(ChronoField.YEAR_OF_ERA)).isEqualTo(jodaLocalDate.getYearOfEra());
+
+        DateTime dateTime = DateTime.now();
+        ZonedDateTime zonedDateTime = ZonedDateTime.ofInstant(java.time.Instant.ofEpochMilli(dateTime.getMillis()), ZoneId.systemDefault());
+
+        assertThat(zonedDateTime.get(ChronoField.ERA)).isEqualTo(dateTime.getEra());
+        assertThat(zonedDateTime.get(ChronoField.YEAR_OF_ERA)).isEqualTo(dateTime.getYearOfEra());
+        assertThat(zonedDateTime.get(ChronoField.MINUTE_OF_DAY)).isEqualTo(dateTime.getMinuteOfDay());
+        assertThat(zonedDateTime.get(ChronoField.SECOND_OF_DAY)).isEqualTo(dateTime.getSecondOfDay());
+        assertThat(zonedDateTime.get(ChronoField.MILLI_OF_SECOND)).isEqualTo(dateTime.getMillisOfSecond());
+        assertThat(zonedDateTime.get(ChronoField.MILLI_OF_DAY)).isEqualTo(dateTime.getMillisOfDay());
+
+    }
+
+    @Test
+    void renamed_methods() {
+
+        org.joda.time.LocalTime jodaLocalTime = new LocalTime(5, 6, 7);
+        java.time.LocalTime javaLocalTime = java.time.LocalTime.of(5, 6, 7);
+
+        assertThat(javaLocalTime.getHour()).isEqualTo(jodaLocalTime.getHourOfDay());
+        assertThat(javaLocalTime.getMinute()).isEqualTo(jodaLocalTime.getMinuteOfHour());
+        assertThat(javaLocalTime.getSecond()).isEqualTo(jodaLocalTime.getSecondOfMinute());
+
+    }
+
+    @Test
+    void getWeekOfWeekyear_ISO() {
+
+        DateTime dateTimeStart = DateTime.now().withMonthOfYear(12).withDayOfMonth(27);
+        ZonedDateTime zonedDateTimeStart = ZonedDateTime.now().withMonth(12).withDayOfMonth(27);
+
+        // Test for the next 50 years
+        for (int i = 0; i < 50; i++) {
+
+            DateTime testDateTime = dateTimeStart.plusYears(i);
+            ZonedDateTime testZonedDateTime = zonedDateTimeStart.plusYears(i);
+
+            // Check 14 days worth
+            for (int j = 0; j < 14; j++) {
+
+                assertThat(testZonedDateTime.plusDays(j).get(IsoFields.WEEK_OF_WEEK_BASED_YEAR)).isEqualTo(testDateTime.plusDays(j).getWeekOfWeekyear());
+
+            }
+
+        }
+
+    }
+
+    @Test
+    void getWeekOfWeekYear_LocaleBased() {
+
+        DateTime dateTimeStart = DateTime.now().withYear(2021).withMonthOfYear(1).withDayOfMonth(1);
+        ZonedDateTime zonedDateTimeStart = ZonedDateTime.now().withYear(2021).withMonth(1).withDayOfMonth(1);
+
+        // Use a Locale that considers Sunday to be part of the week
+        Locale sundayFirstLocale = Locale.US;
+
+        int jodaWeek = dateTimeStart.getWeekOfWeekyear();
+        int isoWeek = zonedDateTimeStart.get(IsoFields.WEEK_OF_WEEK_BASED_YEAR);
+
+        assertThat(isoWeek).isEqualTo(jodaWeek);
+
+        int sundayStartWeek = zonedDateTimeStart.get(WeekFields.SUNDAY_START.weekOfWeekBasedYear());
+        int localeWeek = zonedDateTimeStart.get(WeekFields.of(sundayFirstLocale).weekOfWeekBasedYear());
+
+        assertThat(sundayStartWeek).isNotEqualTo(jodaWeek);
+        assertThat(localeWeek).isNotEqualTo(jodaWeek);
+
+        assertThat(sundayStartWeek).isEqualTo(localeWeek);
+
+    }
+
+    @Test
+    void getWeekyear_ISO() {
+
+        DateTime dateTimeStart = DateTime.now().withMonthOfYear(12).withDayOfMonth(27);
+        ZonedDateTime zonedDateTimeStart = ZonedDateTime.now().withMonth(12).withDayOfMonth(27);
+
+        // Test for the next 50 years
+        for (int i = 0; i < 50; i++) {
+
+            DateTime testDateTime = dateTimeStart.plusYears(i);
+            ZonedDateTime testZonedDateTime = zonedDateTimeStart.plusYears(i);
+
+            // Check 14 days worth
+            for (int j = 0; j < 14; j++) {
+
+                assertThat(testZonedDateTime.plusDays(j).get(IsoFields.WEEK_BASED_YEAR)).isEqualTo(testDateTime.plusDays(j).getWeekyear());
+
+            }
+
+        }
+
+    }
+
+    @Test
+    void getWeekYear_LocaleBased() {
+
+        DateTime dateTimeStart = DateTime.now().withYear(2021).withMonthOfYear(1).withDayOfMonth(1);
+        ZonedDateTime zonedDateTimeStart = ZonedDateTime.now().withYear(2021).withMonth(1).withDayOfMonth(1);
+
+        // Use a Locale that considers Sunday to be part of the week
+        Locale sundayFirstLocale = Locale.US;
+
+        int jodaWeek = dateTimeStart.getWeekyear();
+        int isoWeek = zonedDateTimeStart.get(IsoFields.WEEK_BASED_YEAR);
+
+        assertThat(isoWeek).isEqualTo(jodaWeek);
+
+        int sundayStartWeek = zonedDateTimeStart.get(WeekFields.SUNDAY_START.weekBasedYear());
+        int localeWeek = zonedDateTimeStart.get(WeekFields.of(sundayFirstLocale).weekBasedYear());
+
+        assertThat(sundayStartWeek).isNotEqualTo(jodaWeek);
+        assertThat(localeWeek).isNotEqualTo(jodaWeek);
+
+        assertThat(sundayStartWeek).isEqualTo(localeWeek);
+
+    }
+
+}

--- a/recipes/Java/JodaTimeToJavaTime/Common/get/descriptions/getCenturyOfEra.html
+++ b/recipes/Java/JodaTimeToJavaTime/Common/get/descriptions/getCenturyOfEra.html
@@ -1,0 +1,10 @@
+<html>
+<body>
+<h1>getCenturyOfEra() is not available in java.time</h1>
+<p>The getCenturyOfEra method is no longer supported after migrating from Joda-Time to java.time</p>
+<p>This recipe will replace the getCenturyOfEra method call, with an equivalent calculation which is based on the logic used in Joda-Time to calculate century of era.<p>
+<pre>
+java.lang.Math.abs(<year> / 100)
+</pre>
+</body>
+</html>

--- a/recipes/Java/JodaTimeToJavaTime/Common/get/descriptions/getChronoField.html
+++ b/recipes/Java/JodaTimeToJavaTime/Common/get/descriptions/getChronoField.html
@@ -1,0 +1,21 @@
+<html>
+<body>
+<h1>get<someField>() method is no longer supported</h1>
+<p>Joda-Time provided some convenience methods to access Date/Time fields using a <strong>get</strong> method</p>
+<p>java.time has a smaller set of these convenience methods, so the following are no longer available:
+<ul>
+<li>getEra</li>
+<li>getMillisOfDay</li>
+<li>getMillisOfSecond</li>
+<li>getMinuteOfDay</li>
+<li>getSecondOfDay</li>
+<li>getYearOfEra</li>
+</ul>
+</p>
+<p>There is an equivalent method of retreiving these field values, by using the get(TemporalField field) method. For example
+<pre>
+int milliOfDay = myDateTime.get(ChronoField.MILLI_OF_DAY)
+</pre>
+
+</body>
+</html>

--- a/recipes/Java/JodaTimeToJavaTime/Common/get/descriptions/getMethodRenamed.html
+++ b/recipes/Java/JodaTimeToJavaTime/Common/get/descriptions/getMethodRenamed.html
@@ -1,0 +1,11 @@
+<html>
+<body>
+<p>Joda-Time get<i>Field</i> Method names are different in java.time</p>
+<p>Some methods names are different in java.time, this recipe provides a fix to rewrite to the new method name.</p>
+<ul>
+<li><b>getHourOfDay()</b> has been renamed to <b>getHour()</b></li>
+<li><b>getMinuteOfHour()</b> has been renamed to <b>getMinute()</b></li>
+<li><b>getSecondOfMinute()</b> has been renamed to <b>getSecond()</b></li>
+</ul>
+</body>
+</html>

--- a/recipes/Java/JodaTimeToJavaTime/Common/get/descriptions/getWeekOfWeekyear.html
+++ b/recipes/Java/JodaTimeToJavaTime/Common/get/descriptions/getWeekOfWeekyear.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<body>
+<h3>getWeekOfWeekyear() is no longer available</h3>
+<p>Joda-Time provided a convenience method to get the Week of the Week-Based year from a Date-related object.</p>
+<p>java.time has removed this convenience method. Additionally, there is new behaviour available surrounding week-based years.</p>
+<p>The calculation of Week-based years depends upon which day is considered to be the start of the week, and also how many days minimum should be in the first week of the year.</p>
+<p>Joda-Time getWeekOfWeekyear() followed the ISO standard for these rules which considers Monday to be the start of the week.</p>
+<p>java.time allows you to use locale-dependant Week-Based Years. Some Locales (for example the US) consider Sunday to be the start of the week.</p>
+<p>This recipe provides 3 different fixes available depending on whether you want to migrate to the new behaviour:</p>
+<ul>
+  <li>ISO Week-based year (Same behaviour as Joda-Time)</li>
+  <li>Sunday-Start Week-based year</li>
+  <li>Locale-dependant Week-based year (using Default Locale)</li>
+</ul>
+</body>
+</html>

--- a/recipes/Java/JodaTimeToJavaTime/Common/get/descriptions/getWeekyear.html
+++ b/recipes/Java/JodaTimeToJavaTime/Common/get/descriptions/getWeekyear.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<body>
+<h3>getWeekyear() is no longer available</h3>
+<p>Joda-Time provided a convenience method to get the Week-Based year from a Date-related object.</p>
+<p>java.time has removed this convenience method. Additionally, there is new behaviour available surrounding week-based years.</p>
+<p>The calculation of Week-based years depends upon which day is considered to be the start of the week, and also how many days minimum should be in the first week of the year.</p>
+<p>Joda-Time getWeekyear() followed the ISO standard for these rules which considers Monday to be the start of the week.</p>
+<p>java.time allows you to use locale-dependant Week-Based Years. Some Locales (for example the US) consider Sunday to be the start of the week.</p>
+<p>This recipe provides 3 different fixes available depending on whether you want to migrate to the new behaviour:</p>
+<ul>
+  <li>ISO Week-based year (Same behaviour as Joda-Time)</li>
+  <li>Sunday-Start Week-based year</li>
+  <li>Locale-dependant Week-based year (using Default Locale)</li>
+</ul>
+</body>
+</html>

--- a/recipes/Java/JodaTimeToJavaTime/Common/get/descriptions/getYearOfCentury.html
+++ b/recipes/Java/JodaTimeToJavaTime/Common/get/descriptions/getYearOfCentury.html
@@ -1,0 +1,10 @@
+<html>
+<body>
+<h1>getCenturyOfEra() is not available in java.time</h1>
+<p>The getCenturyOfEra() method is no longer supported after migrating from Joda-Time to java.time</p>
+<p>This recipe will replace the getCenturyOfEra method call, with an equivalent calculation which is based on the logic used in Joda-Time to calculate century of era.<p>
+<pre>
+java.lang.Math.abs(<year> / 100)
+</pre>
+</body>
+</html>

--- a/recipes/Java/JodaTimeToJavaTime/Common/get/descriptions/getYearOfCentury.html
+++ b/recipes/Java/JodaTimeToJavaTime/Common/get/descriptions/getYearOfCentury.html
@@ -2,7 +2,7 @@
 <body>
 <h1>getYearOfCentury() is not available in java.time</h1>
 <p>The getYearOfCentury() method is no longer supported after migrating from Joda-Time to java.time</p>
-<p>This recipe will replace the getYearOfCentury method call, with an equivalent calculation which is based on the logic used in Joda-Time to calculate century of era.<p>
+<p>This recipe will replace the getYearOfCentury method call, with an equivalent calculation which is based on the logic used in Joda-Time to calculate year of century.<p>
 <pre>
 java.lang.Math.abs(<year> % 100)
 </pre>

--- a/recipes/Java/JodaTimeToJavaTime/Common/get/descriptions/getYearOfCentury.html
+++ b/recipes/Java/JodaTimeToJavaTime/Common/get/descriptions/getYearOfCentury.html
@@ -1,10 +1,10 @@
 <html>
 <body>
-<h1>getCenturyOfEra() is not available in java.time</h1>
-<p>The getCenturyOfEra() method is no longer supported after migrating from Joda-Time to java.time</p>
-<p>This recipe will replace the getCenturyOfEra method call, with an equivalent calculation which is based on the logic used in Joda-Time to calculate century of era.<p>
+<h1>getYearOfCentury() is not available in java.time</h1>
+<p>The getYearOfCentury() method is no longer supported after migrating from Joda-Time to java.time</p>
+<p>This recipe will replace the getYearOfCentury method call, with an equivalent calculation which is based on the logic used in Joda-Time to calculate century of era.<p>
 <pre>
-java.lang.Math.abs(<year> / 100)
+java.lang.Math.abs(<year> % 100)
 </pre>
 </body>
 </html>

--- a/recipes/Java/JodaTimeToJavaTime/Common/get/getCenturyOfEra.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/Common/get/getCenturyOfEra.yaml
@@ -1,0 +1,31 @@
+id: scw:java.time:Joda-Time:getCenturyOfEra
+version: 10
+metadata:
+  name: Rewrite getCenturyOfEra to java.time equivalent
+  shortDescription: Rewrite getCenturyOfEra to java.time equivalent
+  level: warning
+  language: java
+  enabled: true
+  comment: |-
+    Joda-Time provided a getCenturyOfEra() method to access the century of era value of a Date-related object.
+    This method is no longer provided in java.time, however you can calculate the equivalent result with a simple equation.
+    This recipe provides a fix to rewrite the getCenturyOfEra() method call to the equivalent equation.
+
+    This recipe is designed to match on broken code as part of an overall migration from Joda-Time to java.time.
+    After an Joda-Time object has been migrated to a java.time equivalent, some subsequent method calls may become invalid as they are no longer provided by java.time.
+    This recipe is designed to match on one of those method calls and provide a fix.
+  descriptionFile: descriptions/getCenturyOfEra.html
+  tags: java.time;framework specific;Joda-Time;quality
+search:
+  methodcall:
+    name: getCenturyOfEra
+    anyOf:
+    - type: java.time.ZonedDateTime
+    - type: java.time.OffsetDateTime
+    - type: java.time.LocalDateTime
+    - type: java.time.LocalDate
+availableFixes:
+- name: Rewrite getCenturyOfEra() to Math.abs(year / 100)
+  actions:
+  - rewrite:
+      to: java.lang.Math.abs({{{ qualifier }}}.getYear() / 100)

--- a/recipes/Java/JodaTimeToJavaTime/Common/get/getChronoField.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/Common/get/getChronoField.yaml
@@ -1,0 +1,39 @@
+id: scw:java.time:Joda-Time:getChronoField
+version: 10
+metadata:
+  name: Rewrite getDateTimeField method to get(ChronoField.DATE_TIME_FIELD)
+  shortDescription: Rewrite getDateTimeField method to get(ChronoField.DATE_TIME_FIELD)
+  level: warning
+  language: java
+  enabled: true
+  comment: |-
+    Joda-Time provided convenience get methods for some less common date and time fields.
+    In java.time these methods have been removed but the field values can still be accessed using the get(ChronoField) method.
+    This recipe provides fixes to transform from the previous method names to the new get(ChronoField) methods.
+
+    This recipe is designed to match on broken code as part of an overall migration from Joda-Time to java.time.
+    After an Joda-Time object has been migrated to a java.time equivalent, some subsequent method calls may become invalid as they are no longer provided by java.time.
+    This recipe is designed to match on one of those method calls and provide a fix.
+  descriptionFile: descriptions/getChronoField.html
+  tags: java.time;framework specific;Joda-Time;quality
+search:
+  methodcall:
+    allOf:
+    - anyOf:
+      - name: getEra
+      - name: getMinuteOfDay
+      - name: getSecondOfDay
+      - name: getYearOfEra
+      - name: getMillisOfSecond
+      - name: getMillisOfDay
+    - anyOf:
+      - type: java.time.ZonedDateTime
+      - type: java.time.OffsetDateTime
+      - type: java.time.LocalDateTime
+      - type: java.time.LocalDate
+      - type: java.time.LocalTime
+availableFixes:
+- name: Rewrite to get(ChronoField.{DATE_TIME_FIELD})
+  actions:
+  - rewrite:
+      to: '{{{ qualifier }}}.get(java.time.temporal.ChronoField.{{#upperCase}}{{#camelToUnderscoreCase}}{{#sed}}s/Millis/Milli/,{{#sed}}s/get//,{{{ methodName }}}{{/sed}}{{/sed}}{{/camelToUnderscoreCase}}{{/upperCase}})'

--- a/recipes/Java/JodaTimeToJavaTime/Common/get/getHourOfDay.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/Common/get/getHourOfDay.yaml
@@ -1,0 +1,30 @@
+id: scw:java.time:Joda-Time:getHourOfDay
+version: 10
+metadata:
+  name: Rewrite getHourOfDay() to getHour()
+  shortDescription: Rewrite getHourOfDay() to getHour()
+  level: warning
+  language: java
+  enabled: true
+  comment: |-
+    The Joda-Time method getHourOfDay() is renamed to getHour() in java.time.
+    This recipe provides a transformation to rewrite the method call to the new method name.
+
+    This recipe is designed to match on broken code as part of an overall migration from Joda-Time to java.time.
+    After an Joda-Time object has been migrated to a java.time equivalent, some subsequent method calls may become invalid as they are no longer provided by java.time.
+    This recipe is designed to match on one of those method calls and provide a fix.
+  descriptionFile: descriptions/getMethodRenamed.html
+  tags: framework specific;java.time;Joda-Time;quality
+search:
+  methodcall:
+    name: getHourOfDay
+    anyOf:
+    - type: java.time.ZonedDateTime
+    - type: java.time.OffsetDateTime
+    - type: java.time.LocalTime
+    - type: java.time.LocalDateTime
+availableFixes:
+- name: Rewrite using java.time equivalent getHour()
+  actions:
+  - rewrite:
+      to: '{{{ qualifier }}}.getHour()'

--- a/recipes/Java/JodaTimeToJavaTime/Common/get/getMinuteOfHour.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/Common/get/getMinuteOfHour.yaml
@@ -1,0 +1,30 @@
+id: scw:java.time:Joda-Time:getMinuteOfHour
+version: 10
+metadata:
+  name: Rewrite getMinuteOfHour() to getMinute()
+  shortDescription: Rewrite getMinuteOfHour() to getMinute()
+  level: warning
+  language: java
+  enabled: true
+  comment: |-
+    The Joda-Time method getMinuteOfHour() is renamed to getMinute() in java.time.
+    This recipe provides a transformation to rewrite the method call to the new method name.
+
+    This recipe is designed to match on broken code as part of an overall migration from Joda-Time to java.time.
+    After an Joda-Time object has been migrated to a java.time equivalent, some subsequent method calls may become invalid as they are no longer provided by java.time.
+    This recipe is designed to match on one of those method calls and provide a fix.
+  descriptionFile: descriptions/getMethodRenamed.html
+  tags: framework specific;java.time;Joda-Time;quality
+search:
+  methodcall:
+    name: getMinuteOfHour
+    anyOf:
+    - type: java.time.ZonedDateTime
+    - type: java.time.OffsetDateTime
+    - type: java.time.LocalDateTime
+    - type: java.time.LocalTime
+availableFixes:
+- name: Rewrite using java.time equivalent getMinute()
+  actions:
+  - rewrite:
+      to: '{{{ qualifier }}}.getMinute()'

--- a/recipes/Java/JodaTimeToJavaTime/Common/get/getSecondOfMinute.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/Common/get/getSecondOfMinute.yaml
@@ -1,0 +1,30 @@
+id: scw:java.time:Joda-Time:getSecondOfMinute
+version: 10
+metadata:
+  name: Rewrite getSecondOfMinute() to getSecond()
+  shortDescription: Rewrite getSecondOfMinute() to getSecond()
+  level: warning
+  language: java
+  enabled: true
+  comment: |-
+    The Joda-Time method getSecondOfMinute() is renamed to getSecond() in java.time.
+    This recipe provides a transformation to rewrite the method call to the new method name.
+
+    This recipe is designed to match on broken code as part of an overall migration from Joda-Time to java.time.
+    After an Joda-Time object has been migrated to a java.time equivalent, some subsequent method calls may become invalid as they are no longer provided by java.time.
+    This recipe is designed to match on one of those method calls and provide a fix.
+  descriptionFile: descriptions/getMethodRenamed.html
+  tags: framework specific;java.time;Joda-Time;quality
+search:
+  methodcall:
+    name: getSecondOfMinute
+    anyOf:
+    - type: java.time.ZonedDateTime
+    - type: java.time.OffsetDateTime
+    - type: java.time.LocalDateTime
+    - type: java.time.LocalTime
+availableFixes:
+- name: Rewrite using java.time equivalent getSecond()
+  actions:
+  - rewrite:
+      to: '{{{ qualifier }}}.getSecond()'

--- a/recipes/Java/JodaTimeToJavaTime/Common/get/getWeekOfWeekyear.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/Common/get/getWeekOfWeekyear.yaml
@@ -1,0 +1,41 @@
+id: scw:java.time:Joda-Time:getWeekofWeekyear
+version: 10
+metadata:
+  name: Rewrite getWeekOfWeekyear() to java.time equivalent
+  shortDescription: Rewrite getWeekOfWeekyear() to java.time equivalent
+  level: warning
+  language: java
+  enabled: true
+  comment: |-
+    Joda-Time provided getWeekOfWeekyear() method which provided a value based on an ISO8601 Week-based year.
+    In java.time this method has been removed but the same value can still be accessed using the get(ChronoField) method.
+    Additionally java.time provides the ability to use a Week-based year based on Locale-specific rules.
+    This recipe provides fixes to transform from the previous method names to the new get(ChronoField) methods.
+
+    This recipe is designed to match on broken code as part of an overall migration from Joda-Time to java.time.
+    After an Joda-Time object has been migrated to a java.time equivalent, some subsequent method calls may become invalid as they are no longer provided by java.time.
+    This recipe is designed to match on one of those method calls and provide a fix.
+  descriptionFile: descriptions/getWeekOfWeekyear.html
+  tags: framework specific;java.time;Joda-Time;quality
+search:
+  methodcall:
+    argCount: 0
+    name: getWeekOfWeekyear
+    anyOf:
+    - type: java.time.ZonedDateTime
+    - type: java.time.OffsetDateTime
+    - type: java.time.LocalDateTime
+    - type: java.time.LocalDate
+availableFixes:
+- name: Rewrite using ISO Weekyear (Same as Joda-Time)
+  actions:
+  - rewrite:
+      to: '{{{ qualifier }}}.get(java.time.temporal.IsoFields.WEEK_OF_WEEK_BASED_YEAR)'
+- name: Rewrite using Locale-dependant Weekyear
+  actions:
+  - rewrite:
+      to: '{{{ qualifier }}}.get(java.time.temporal.WeekFields.of(java.util.Locale.getDefault()).weekOfWeekBasedYear())'
+- name: Rewrite using SundayStart Weekyear
+  actions:
+  - rewrite:
+      to: '{{{ qualifier }}}.get(java.time.temporal.WeekFields.SUNDAY_START.weekOfWeekBasedYear())'

--- a/recipes/Java/JodaTimeToJavaTime/Common/get/getWeekyear.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/Common/get/getWeekyear.yaml
@@ -1,0 +1,41 @@
+id: scw:java.time:Joda-Time:getWeekyear
+version: 10
+metadata:
+  name: Rewrite getWeekyear() to java.time equivalent
+  shortDescription: Rewrite getWeekyear() to java.time equivalent
+  level: warning
+  language: java
+  enabled: true
+  comment: |-
+    Joda-Time provided getWeekyear() method which provided a value based on an ISO8601 Week-based year.
+    In java.time this method has been removed but the same value can still be accessed using the get(ChronoField) method.
+    Additionally java.time provides the ability to use a Week-based year based on Locale-specific rules.
+    This recipe provides fixes to transform from the previous method names to the new get(ChronoField) methods.
+
+    This recipe is designed to match on broken code as part of an overall migration from Joda-Time to java.time.
+    After an Joda-Time object has been migrated to a java.time equivalent, some subsequent method calls may become invalid as they are no longer provided by java.time.
+    This recipe is designed to match on one of those method calls and provide a fix.
+  descriptionFile: descriptions/getWeekyear.html
+  tags: framework specific;java.time;Joda-Time;quality
+search:
+  methodcall:
+    argCount: 0
+    name: getWeekyear
+    anyOf:
+    - type: java.time.ZonedDateTime
+    - type: java.time.OffsetDateTime
+    - type: java.time.LocalDateTime
+    - type: java.time.LocalDate
+availableFixes:
+- name: Rewrite using ISO Weekyear (Same as Joda-Time)
+  actions:
+  - rewrite:
+      to: '{{{ qualifier }}}.get(java.time.temporal.IsoFields.WEEK_BASED_YEAR)'
+- name: Rewrite using Locale-dependant Weekyear
+  actions:
+  - rewrite:
+      to: '{{{ qualifier }}}.get(java.time.temporal.WeekFields.of(java.util.Locale.getDefault()).weekBasedYear())'
+- name: Rewrite using SUNDAY_START Weekyear
+  actions:
+  - rewrite:
+      to: '{{{ qualifier }}}.get(java.time.temporal.WeekFields.SUNDAY_START.weekBasedYear())'

--- a/recipes/Java/JodaTimeToJavaTime/Common/get/getYearOfCentury.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/Common/get/getYearOfCentury.yaml
@@ -1,0 +1,31 @@
+id: scw:java.time:Joda-Time:getYearOfCentury
+version: 10
+metadata:
+  name: Rewrite getYearOfCentury() to java.time equivalent
+  shortDescription: Rewrite getYearOfCentury() to java.time equivalent
+  level: warning
+  language: java
+  enabled: true
+  comment: |-
+    Joda-Time provided a getYearOfCentury() method to access the year-of-century value of a Date-related object.
+    This method is no longer provided in java.time, however you can calculate the equivalent result with a simple equation.
+    This recipe provides a fix to rewrite the getYearOfCentury() method call to the equivalent equation.
+
+    This recipe is designed to match on broken code as part of an overall migration from Joda-Time to java.time.
+    After an Joda-Time object has been migrated to a java.time equivalent, some subsequent method calls may become invalid as they are no longer provided by java.time.
+    This recipe is designed to match on one of those method calls and provide a fix.
+  descriptionFile: descriptions/getYearOfCentury.html
+  tags: java.time;framework specific;Joda-Time;quality
+search:
+  methodcall:
+    name: getYearOfCentury
+    anyOf:
+    - type: java.time.ZonedDateTime
+    - type: java.time.OffsetDateTime
+    - type: java.time.LocalDateTime
+    - type: java.time.LocalDate
+availableFixes:
+- name: Rewrite getYearOfCentury() to Math.abs(getYear() % 100)
+  actions:
+  - rewrite:
+      to: java.lang.Math.abs({{{ qualifier }}}.getYear() % 100)

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-getMillis.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-getMillis.yaml
@@ -1,0 +1,23 @@
+id: scw:java.time:Joda-Time:DateTime-getMillis
+version: 10
+metadata:
+  name: Rewrite getMillis() to .toInstant().toEpochMilli()
+  shortDescription: Rewrite getMillis() to .toInstant().toEpochMilli()
+  level: warning
+  language: java
+  enabled: true
+  comment: "Joda-time DateTime provided a getMillis() method used to get the Milliseconds since Epoch.\nIn java.time this method is no longer available. \nTo achieve the same result you can first convert the ZonedDatetime or OffsetDateTime to an Instant, and then use the Instant's toEpochMilli() method.\n\nThis recipe is designed to match on broken code as part of an overall migration from Joda-Time to java.time.\nAfter an Joda-Time object has been migrated to a java.time equivalent, some subsequent method calls may become invalid as they are no longer provided by java.time.\nThis recipe is designed to match on one of those method calls and provide a fix."
+  descriptionFile: descriptions/getMillis.html
+  tags: framework specific;java.time;Joda-Time;quality
+search:
+  methodcall:
+    argCount: 0
+    name: getMillis
+    anyOf:
+    - type: java.time.ZonedDateTime
+    - type: java.time.OffsetDateTime
+availableFixes:
+- name: Rewrite using java.time .toInstant().toEpochMilli()
+  actions:
+  - rewrite:
+      to: '{{{ qualifier }}}.toInstant().toEpochMilli()'

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-getMillis.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-getMillis.yaml
@@ -6,7 +6,14 @@ metadata:
   level: warning
   language: java
   enabled: true
-  comment: "Joda-time DateTime provided a getMillis() method used to get the Milliseconds since Epoch.\nIn java.time this method is no longer available. \nTo achieve the same result you can first convert the ZonedDatetime or OffsetDateTime to an Instant, and then use the Instant's toEpochMilli() method.\n\nThis recipe is designed to match on broken code as part of an overall migration from Joda-Time to java.time.\nAfter an Joda-Time object has been migrated to a java.time equivalent, some subsequent method calls may become invalid as they are no longer provided by java.time.\nThis recipe is designed to match on one of those method calls and provide a fix."
+  comment: |
+    Joda-time DateTime provided a getMillis() method used to get the Milliseconds since Epoch.
+    In java.time this method is no longer available.
+    To achieve the same result you can first convert the ZonedDatetime or OffsetDateTime to an Instant, and then use the Instant's toEpochMilli() method.
+
+    This recipe is designed to match on broken code as part of an overall migration from Joda-Time to java.time.
+    After an Joda-Time object has been migrated to a java.time equivalent, some subsequent method calls may become invalid as they are no longer provided by java.time.
+    This recipe is designed to match on one of those method calls and provide a fix.
   descriptionFile: descriptions/getMillis.html
   tags: framework specific;java.time;Joda-Time;quality
 search:

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/descriptions/getMillis.html
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/descriptions/getMillis.html
@@ -1,0 +1,10 @@
+<html>
+<body>
+<h1>getMillis() is not available in java.time</h1>
+<p>Joda-Time provided a getMillis() method which returned the milliseconds since epoch.</p>
+<p>java.time does not provide this method however the same result can be achieved by converting to an Instant and using the Instant's toEpochMilli() method.</p>
+<pre>
+int epochMillis = zonedDateTime.toInstant().toEpochMilli();
+</pre>
+</body>
+</html


### PR DESCRIPTION
Closes SEN-2541

This set of recipes covers the migration of some methods that are common
to a range of java.time classes.

Tests that demonstrate and support the logic of the recipes are included
in CommonGetMethodsTest.

Note: the DateTime getMillis recipe is also included, I originally
thought this would be a common method but it is really only for DateTime
and it's corresponding java.time objects. I have included it anyway but
it is in the DateTime folder to reflect it is only for DateTime migration.