### PR TITLE
SEN-2535 Recipes for migration of Joda DateTime instance methods

### DIFF
--- a/example_code/joda-time-to-java-time-examples/src/test/java/includetimezone/DateTimeExamplesTest.java
+++ b/example_code/joda-time-to-java-time-examples/src/test/java/includetimezone/DateTimeExamplesTest.java
@@ -1,0 +1,543 @@
+package includetimezone;
+
+import org.joda.time.*;
+import org.junit.jupiter.api.Test;
+import util.JodaTimeToJavaTimeTestUtil;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.*;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoField;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class DateTimeExamplesTest {
+
+
+    @Test
+    public void test_constructor_with_millis_same_as_of_with_nanos() {
+
+        int year = 2021;
+        int month = 11;
+        int day = 8;
+        int hour = 4;
+        int minute = 45;
+        int seconds = 23;
+        int millis = 33;
+
+
+        org.joda.time.DateTime jodaDateTime = new DateTime(year, month, day, hour, minute, seconds, millis, DateTimeZone.UTC);
+
+        java.time.ZonedDateTime javaDateTime = java.time.ZonedDateTime.of(year, month, day, hour, minute, seconds,0, ZoneId.of("UTC")).with(ChronoField.MILLI_OF_SECOND, millis);
+
+        long jodaDateTimeMillis = jodaDateTime.getMillis();
+        long javaDateTimeMillis = javaDateTime.toInstant().toEpochMilli();
+
+        assertEquals(jodaDateTimeMillis, javaDateTimeMillis);
+
+
+    }
+
+    /*
+        This test is to demonstrate that the Joda-Time method:
+            toDateTime(DateTimeZone)
+            toMutableDateTime(DateTimeZone) with obvious side effects
+        Is equivalent to the java.time methods:
+            ZonedDateTime  withZoneSameInstant(ZoneId)
+            OffsetDateTime atZoneSameInstant(ZoneId)
+    */
+    @Test
+    public void test_toDateTime_ZoneID() {
+
+
+        DateTimeZone maldives = DateTimeZone.forID("Indian/Maldives");
+        ZoneId maldivesZoneId = ZoneId.of("Indian/Maldives");
+
+        DateTime dateTimeHere = DateTime.now();
+        long originalLong = dateTimeHere.getMillis();
+
+        DateTime dateTimeMaldives = dateTimeHere.toDateTime(maldives);
+
+        // Test Equivalent Functionality in java.time
+        MutableDateTime mutableDateTimeMaldives = dateTimeHere.toMutableDateTime(maldives);
+        java.time.ZonedDateTime zdt = Instant.ofEpochMilli(originalLong).atZone(ZoneId.systemDefault());
+        java.time.OffsetDateTime odt = zdt.toOffsetDateTime();
+        java.time.ZonedDateTime zdtMaldives = zdt.withZoneSameInstant(maldivesZoneId);
+        java.time.ZonedDateTime odtMaldives = odt.atZoneSameInstant(maldivesZoneId);
+
+        long zdtLong = zdt.toInstant().toEpochMilli();
+        long mutableLongMaldives = mutableDateTimeMaldives.getMillis();
+        long zdtLongMaldives = zdtMaldives.toInstant().toEpochMilli();
+        long odtLongMaldives = odtMaldives.toInstant().toEpochMilli();
+
+        // All Represent the same instant
+        assertThat(zdtLongMaldives).isEqualTo(zdtLong).isEqualTo(odtLongMaldives).isEqualTo(originalLong).isEqualTo(mutableLongMaldives);
+
+        // Default Zone all have the same hour
+        assertThat(dateTimeHere.getHourOfDay())
+                .isEqualTo(zdt.getHour())
+                .isEqualTo(odt.getHour());
+
+        // Maldives Zone all have the same hour
+        assertThat(dateTimeMaldives.getHourOfDay())
+                .isEqualTo(zdtMaldives.getHour())
+                .isEqualTo(mutableDateTimeMaldives.getHourOfDay())
+                .isEqualTo(odtMaldives.getHour());
+
+        // Hour is different here and maldives
+        assertThat(dateTimeHere.getHourOfDay()).isNotEqualTo(dateTimeMaldives.getHourOfDay());
+
+
+    }
+
+    @Test
+    public void test_constructors_equivalent() {
+
+        Date date = new Date();
+
+        // Test equivalent used for recipe DateTime-constructor-Date
+        DateTime fromDate = new DateTime(date);
+        ZonedDateTime fromDateZdt = ZonedDateTime.ofInstant(date.toInstant(), java.time.ZoneId.systemDefault());
+        OffsetDateTime fromDateOdt = OffsetDateTime.ofInstant(date.toInstant(), java.time.ZoneId.systemDefault());
+
+        assertThat(fromDate.getMillis()).isEqualTo(fromDateZdt.toInstant().toEpochMilli());
+        assertThat(fromDate.getMillis()).isEqualTo(fromDateOdt.toInstant().toEpochMilli());
+
+        assertThat(fromDate.getHourOfDay()).isEqualTo(fromDateZdt.getHour());
+        assertThat(fromDate.getHourOfDay()).isEqualTo(fromDateOdt.getHour());
+
+        assertThat(fromDate.getMinuteOfHour()).isEqualTo(fromDateZdt.getMinute());
+        assertThat(fromDate.getMinuteOfHour()).isEqualTo(fromDateOdt.getMinute());
+
+
+    }
+
+    /*
+        This test is to demonstrate that the Joda-Time method:
+            withZone(DateTimeZone)
+        Is equivalent to the java.time methods:
+            ZonedDateTime withZoneSameInstant(ZoneId)
+            OffsetDateTime atZoneSameInstant(ZoneId)
+    */
+    @Test
+    void withZone_DateTimeZone() {
+
+        // Establish the instant will we test
+        DateTime dateTime = DateTime.now();
+        long originalLong = dateTime.getMillis();
+
+        // Zones to use
+        DateTimeZone maldives = DateTimeZone.forID("Indian/Maldives");
+        ZoneId maldivesZoneId = ZoneId.of("Indian/Maldives");
+
+        // Get Maldives DateTime using Joda-Time
+        DateTime dateTimeMaldives = dateTime.withZone(maldives);
+
+        // Test Equivalent Functionality in java.time
+        java.time.ZonedDateTime zdt = Instant.ofEpochMilli(originalLong).atZone(ZoneId.systemDefault());
+        java.time.ZonedDateTime zdtMaldives = zdt.withZoneSameInstant(maldivesZoneId);
+        java.time.OffsetDateTime odt = zdt.toOffsetDateTime();
+        java.time.ZonedDateTime odtMaldives = odt.atZoneSameInstant(maldivesZoneId);
+
+        // All Dates should represent the same instant
+        assertThat(originalLong).isEqualTo(dateTime.getMillis());
+        assertThat(originalLong).isEqualTo(dateTimeMaldives.getMillis());
+        assertThat(originalLong).isEqualTo(zdt.toInstant().toEpochMilli());
+        assertThat(originalLong).isEqualTo(zdtMaldives.toInstant().toEpochMilli());
+        assertThat(originalLong).isEqualTo(odtMaldives.toInstant().toEpochMilli());
+
+        // ZonedDateTime should be the same hour of day in both Joda-Time and java.time
+        assertThat(dateTime.getHourOfDay()).isEqualTo(zdt.getHour());
+        assertThat(dateTime.getHourOfDay()).isEqualTo(odt.getHour());
+
+        // Hours of Day should be different in Maldives
+        assertThat(dateTime.getHourOfDay()).isNotEqualTo(dateTimeMaldives.getHourOfDay());
+        assertThat(zdt.getHour()).isNotEqualTo(zdtMaldives.getHour());
+        assertThat(odt.getHour()).isNotEqualTo(odtMaldives.getHour());
+
+        // DateTime Maldives and ZonedDateTime maldives should have the same hour
+        assertThat(dateTimeMaldives.getHourOfDay()).isEqualTo(zdtMaldives.getHour()).isEqualTo(odtMaldives.getHour());
+
+    }
+
+    /*
+        This test is to demonstrate that the Joda-Time method:
+            withZoneRetainFields(DateTimeZone)
+        Is equivalent to the java.time methods:
+            ZonedDateTime: withZoneSameLocal(ZoneId)
+            OffsetDateTime: atZoneSimilarLocal(ZoneId)
+    */
+    @Test
+    void withZoneRetainFields_DateTimeZone() {
+
+        // Establish the instant will we test
+        DateTime dateTime = DateTime.now();
+        long originalLong = dateTime.getMillis();
+
+        // Zones to use
+        DateTimeZone maldivesDateTimeZone = DateTimeZone.forID("Indian/Maldives");
+        ZoneId maldivesZoneId = ZoneId.of("Indian/Maldives");
+
+        // Get Maldives DateTime using Joda-Time withZoneRetainFields
+        DateTime dateTimeMaldives = dateTime.withZoneRetainFields(maldivesDateTimeZone);
+
+        // Test Equivalent Functionality in java.time
+        java.time.ZonedDateTime zdt = Instant.ofEpochMilli(originalLong).atZone(ZoneId.systemDefault());
+        java.time.ZonedDateTime zdtMaldives = zdt.withZoneSameLocal(maldivesZoneId);
+        java.time.OffsetDateTime odt = zdt.toOffsetDateTime();
+        java.time.ZonedDateTime odtMaldives = odt.atZoneSimilarLocal(maldivesZoneId);
+
+        // Default Zone Dates should represent the same instant
+        assertThat(originalLong).isEqualTo(dateTime.getMillis());
+        assertThat(originalLong).isEqualTo(zdt.toInstant().toEpochMilli());
+        assertThat(originalLong).isEqualTo(odt.toInstant().toEpochMilli());
+
+        // Maldives dates represent a different instant
+        assertThat(originalLong).isNotEqualTo(dateTimeMaldives.getMillis());
+        assertThat(originalLong).isNotEqualTo(zdtMaldives.toInstant().toEpochMilli());
+        assertThat(originalLong).isNotEqualTo(odtMaldives.toInstant().toEpochMilli());
+
+        // Maldives Dates both represent the same instant
+        assertThat(dateTimeMaldives.getMillis()).isEqualTo(zdtMaldives.toInstant().toEpochMilli());
+        assertThat(dateTimeMaldives.getMillis()).isEqualTo(odtMaldives.toInstant().toEpochMilli());
+
+        // ZonedDateTime should be the same hour of day in both Joda-Time and java.time
+        assertThat(dateTime.getHourOfDay()).isEqualTo(zdt.getHour());
+        assertThat(dateTime.getHourOfDay()).isEqualTo(odt.getHour());
+
+        // Hours of Day should be same for Default Zone and Maldives
+        assertThat(dateTime.getHourOfDay()).isEqualTo(dateTimeMaldives.getHourOfDay());
+        assertThat(zdt.getHour()).isEqualTo(zdtMaldives.getHour());
+        assertThat(odt.getHour()).isEqualTo(odtMaldives.getHour());
+
+        // DateTime Maldives and ZonedDateTime maldives should have the same hour
+        assertThat(dateTimeMaldives.getHourOfDay()).isEqualTo(zdtMaldives.getHour()).isEqualTo(odtMaldives.getHour());
+
+    }
+
+    @Test
+    public void dateTime_toString() {
+
+        ZonedDateTime now = ZonedDateTime.now();
+
+        test_datetime_toString(now);
+
+        //String pattern = "uuuu-MM-dd'T'HH:mm:ss.SSSX"
+        test_datetime_toString(now.withNano(0));
+        test_datetime_toString(now.withNano(10));
+        test_datetime_toString(now.withNano(100));
+        test_datetime_toString(now.withNano(1000));
+        test_datetime_toString(now.withNano(10000));
+        test_datetime_toString(now.withNano(100000));
+        test_datetime_toString(now.withNano(1000000));
+        test_datetime_toString(now.withNano(10000000));
+        test_datetime_toString(now.withNano(900000000));
+        test_datetime_toString(now.withNano(987654321));
+        test_datetime_toString(now.withNano(123456789));
+        test_datetime_toString(now.withSecond(0));
+        test_datetime_toString(now.withMinute(0).withSecond(0));
+
+    }
+
+    private void test_datetime_toString(ZonedDateTime zonedDateTime) {
+
+        long instant = zonedDateTime.toInstant().toEpochMilli();
+
+        ZoneId.getAvailableZoneIds()
+                .stream().filter(z -> !z.startsWith("System"))
+                .forEach(zoneId -> {
+
+            DateTimeZone dateTimeZone = DateTimeZone.forID(zoneId);
+
+            // Create a Joda-Time DateTime at this instant in the specified Zone
+            DateTime dt = org.joda.time.Instant.ofEpochMilli(instant).toDateTime(dateTimeZone);
+            // Create a java.time ZonedDateTime at this instant in the specified Zone
+            ZonedDateTime zdt = ZonedDateTime.ofInstant(Instant.ofEpochMilli(instant), ZoneId.of(zoneId));
+            OffsetDateTime odt = zdt.toOffsetDateTime();
+
+            String pattern = "uuuu-MM-dd'T'HH:mm:ss.SSSXXX";
+
+            assertThat(zdt.format(DateTimeFormatter.ofPattern(pattern))).isEqualTo(dt.toString());
+            assertThat(odt.format(DateTimeFormatter.ofPattern(pattern))).isEqualTo(dt.toString());
+
+        });
+
+    }
+
+    @Test
+    void getMillis() {
+
+        DateTime dateTime = DateTime.now();
+        ZonedDateTime zonedDateTime = ZonedDateTime.ofInstant(java.time.Instant.ofEpochMilli(dateTime.getMillis()), ZoneId.systemDefault());
+
+        assertThat(zonedDateTime.toInstant().toEpochMilli()).isEqualTo(dateTime.getMillis());
+
+    }
+
+    @Test
+    void isAfterNow() {
+
+        DateTime dateTime = DateTime.now().withTimeAtStartOfDay();
+
+        for (int i = 0; i < 24; i++) {
+
+            ZonedDateTime zonedDateTime = equivalentZonedDateTime(dateTime);
+            OffsetDateTime offsetDateTime = zonedDateTime.toOffsetDateTime();
+
+            assertThat(zonedDateTime.isAfter(ZonedDateTime.now())).isEqualTo(dateTime.isAfterNow());
+            assertThat(offsetDateTime.isAfter(OffsetDateTime.now())).isEqualTo(dateTime.isAfterNow());
+
+        }
+
+    }
+
+    @Test
+    void isBeforeNow() {
+
+        DateTime dateTime = DateTime.now().withTimeAtStartOfDay();
+
+        for (int i = 0; i < 24; i++) {
+
+            ZonedDateTime zonedDateTime = equivalentZonedDateTime(dateTime);
+            OffsetDateTime offsetDateTime = zonedDateTime.toOffsetDateTime();
+
+            assertThat(zonedDateTime.isBefore(ZonedDateTime.now())).isEqualTo(dateTime.isBeforeNow());
+            assertThat(offsetDateTime.isBefore(OffsetDateTime.now())).isEqualTo(dateTime.isBeforeNow());
+
+        }
+
+    }
+
+    private ZonedDateTime equivalentZonedDateTime(DateTime dateTime) {
+        ZoneId zoneId = ZoneId.of(dateTime.getZone().getID());
+        return ZonedDateTime.ofInstant(Instant.ofEpochMilli(dateTime.getMillis()), zoneId);
+    }
+
+    @Test
+    void minus_long() {
+
+        LongStream.range(-10000, 10000).forEach(l -> {
+
+            DateTime dateTime = DateTime.now();
+            DateTime dateTimeResult = dateTime.minus(l);
+
+            ZonedDateTime zonedDateTime = equivalentZonedDateTime(dateTime);
+            OffsetDateTime offsetDateTime = zonedDateTime.toOffsetDateTime();
+
+            ZonedDateTime zonedDateTimeResult = zonedDateTime.minus(l, ChronoUnit.MILLIS);
+            OffsetDateTime offsetDateTimeResult = offsetDateTime.minus(l, ChronoUnit.MILLIS);
+
+            JodaTimeToJavaTimeTestUtil.assertSameInstantAndZoneId(dateTimeResult, zonedDateTimeResult);
+            JodaTimeToJavaTimeTestUtil.assertSameInstantAndOffset(dateTimeResult, offsetDateTimeResult);
+
+        });
+
+    }
+
+    @Test
+    void plus_long() {
+
+        LongStream.range(-10000, 10000).forEach(l -> {
+
+            DateTime dateTime = DateTime.now();
+            DateTime dateTimeResult = dateTime.plus(l);
+
+            ZonedDateTime zonedDateTime = equivalentZonedDateTime(dateTime);
+            OffsetDateTime offsetDateTime = zonedDateTime.toOffsetDateTime();
+
+            ZonedDateTime zonedDateTimeResult = zonedDateTime.plus(l, ChronoUnit.MILLIS);
+            OffsetDateTime offsetDateTimeResult = offsetDateTime.plus(l, ChronoUnit.MILLIS);
+
+            JodaTimeToJavaTimeTestUtil.assertSameInstantAndZoneId(dateTimeResult, zonedDateTimeResult);
+            JodaTimeToJavaTimeTestUtil.assertSameInstantAndOffset(dateTimeResult, offsetDateTimeResult);
+
+
+        });
+
+    }
+
+    @Test
+    void toDate() {
+
+        DateTime dateTime = DateTime.now();
+        ZonedDateTime zonedDateTime = equivalentZonedDateTime(dateTime);
+        OffsetDateTime offsetDateTime = zonedDateTime.toOffsetDateTime();
+
+        Date date = dateTime.toDate();
+
+        Date zdtDate = Date.from(zonedDateTime.toInstant());
+        Date odtDate = Date.from(offsetDateTime.toInstant());
+
+        assertThat(zdtDate).isEqualTo(date);
+        assertThat(odtDate).isEqualTo(date);
+
+    }
+
+    @Test
+    void toDateMidnight() {
+
+        String testZone = "Asia/Tokyo";
+        ZoneId zoneId = ZoneId.of(testZone);
+        DateTime dateTime = DateTime.now().withZone(DateTimeZone.forID(testZone));
+        ZonedDateTime zonedDateTime = equivalentZonedDateTime(dateTime);
+        OffsetDateTime offsetDateTime = zonedDateTime.toOffsetDateTime();
+
+        DateMidnight dateMidnight = dateTime.toDateMidnight();
+        ZonedDateTime zdt = zonedDateTime.toLocalDate().atStartOfDay(zonedDateTime.getZone());
+        OffsetDateTime odt = offsetDateTime.toLocalDate().atStartOfDay().atOffset(offsetDateTime.getOffset());
+
+        JodaTimeToJavaTimeTestUtil.assertSameInstantAndZoneId(dateMidnight.toDateTime(), zdt);
+        JodaTimeToJavaTimeTestUtil.assertSameInstantAndOffset(dateMidnight.toDateTime(), odt);
+
+    }
+
+    @Test
+    void toDateTime_DateTimeZone() {
+
+        Set<String> zoneIds = new HashSet<>();
+
+        zoneIds.add("Asia/Tokyo");
+        zoneIds.add("Europe/Berlin");
+        zoneIds.add("Europe/Helsinki");
+        zoneIds.add("America/Denver");
+        zoneIds.add("Europe/Stockholm");
+        zoneIds.add("Europe/Lisbon");
+        zoneIds.add("Africa/Nairobi");
+        zoneIds.add("America/Rio_Branco");
+
+        DateTime dateTime = DateTime.now();
+        ZonedDateTime zonedDateTime = equivalentZonedDateTime(dateTime);
+        OffsetDateTime offsetDateTime = zonedDateTime.toOffsetDateTime();
+
+        zoneIds.forEach(z -> {
+
+            ZoneId zoneId = ZoneId.of(z);
+            DateTimeZone dateTimeZone = DateTimeZone.forID(z);
+
+            DateTime dateTimeThere = dateTime.toDateTime(dateTimeZone);
+            MutableDateTime mutableDateTimeThere = dateTime.toMutableDateTime(dateTimeZone);
+
+            ZonedDateTime zonedDateTimeThere = zonedDateTime.withZoneSameInstant(zoneId);
+            ZonedDateTime zonedDateTimeThereFromOffsetDateTime = offsetDateTime.atZoneSameInstant(zoneId);
+
+            JodaTimeToJavaTimeTestUtil.assertSameInstantAndZoneId(dateTimeThere, zonedDateTimeThere);
+            JodaTimeToJavaTimeTestUtil.assertSameInstantAndZoneId(dateTimeThere, zonedDateTimeThereFromOffsetDateTime);
+            JodaTimeToJavaTimeTestUtil.assertSameInstantAndZoneId(mutableDateTimeThere, zonedDateTimeThere);
+            JodaTimeToJavaTimeTestUtil.assertSameInstantAndZoneId(mutableDateTimeThere, zonedDateTimeThereFromOffsetDateTime);
+
+        });
+
+        IntStream.range(-12,14).forEach(o -> {
+
+            DateTimeZone dateTimeZoneOffset = DateTimeZone.forOffsetHours(o);
+            ZoneOffset zoneOffset = ZoneOffset.ofHours(o);
+
+            DateTime dateTimeOffset = dateTime.toDateTime(dateTimeZoneOffset);
+            MutableDateTime mutableDateTimeOffset = dateTime.toMutableDateTime(dateTimeZoneOffset);
+            OffsetDateTime offsetDateTimeOffset = offsetDateTime.withOffsetSameInstant(zoneOffset);
+
+            JodaTimeToJavaTimeTestUtil.assertSameInstantAndOffset(dateTimeOffset, offsetDateTimeOffset);
+            JodaTimeToJavaTimeTestUtil.assertSameInstantAndOffset(mutableDateTimeOffset, offsetDateTimeOffset);
+
+        });
+
+    }
+
+    @Test
+    void toDateTime() {
+
+        DateTime dateTime = DateTime.now();
+        ZonedDateTime zonedDateTime = equivalentZonedDateTime(dateTime);
+        OffsetDateTime offsetDateTime = zonedDateTime.toOffsetDateTime();
+
+        JodaTimeToJavaTimeTestUtil.assertSameInstantAndZoneId(dateTime.toDateTime(), zonedDateTime);
+        JodaTimeToJavaTimeTestUtil.assertSameInstantAndZoneId(dateTime.toDateTimeISO(), zonedDateTime);
+
+        JodaTimeToJavaTimeTestUtil.assertSameInstantAndOffset(dateTime.toDateTime(), offsetDateTime);
+        JodaTimeToJavaTimeTestUtil.assertSameInstantAndOffset(dateTime.toDateTimeISO(), offsetDateTime);
+
+    }
+
+    @Test
+    void toMutableDateTime() {
+
+        DateTime dateTime = DateTime.now();
+        ZonedDateTime zonedDateTime = equivalentZonedDateTime(dateTime);
+        OffsetDateTime offsetDateTime = zonedDateTime.toOffsetDateTime();
+
+        JodaTimeToJavaTimeTestUtil.assertSameInstantAndZoneId(dateTime.toMutableDateTime(), zonedDateTime);
+        JodaTimeToJavaTimeTestUtil.assertSameInstantAndZoneId(dateTime.toMutableDateTimeISO(), zonedDateTime);
+
+        JodaTimeToJavaTimeTestUtil.assertSameInstantAndOffset(dateTime.toMutableDateTime(), offsetDateTime);
+        JodaTimeToJavaTimeTestUtil.assertSameInstantAndOffset(dateTime.toMutableDateTimeISO(), offsetDateTime);
+
+    }
+
+    @Test
+    void toGregorianCalendar() {
+
+        DateTime dateTime = DateTime.now();
+        ZonedDateTime zonedDateTime = equivalentZonedDateTime(dateTime);
+        OffsetDateTime offsetDateTime = zonedDateTime.toOffsetDateTime();
+
+        GregorianCalendar gcDateTime = dateTime.toGregorianCalendar();
+        GregorianCalendar gcZonedDateTime = GregorianCalendar.from(zonedDateTime);
+        GregorianCalendar gcOffsetDateTime = GregorianCalendar.from(offsetDateTime.toZonedDateTime());
+
+        // Assert GregorianCalendar from zonedDateTime has same TimeZone and Millis
+        assertThat(gcZonedDateTime.getTimeZone()).isEqualTo(gcDateTime.getTimeZone());
+        assertThat(gcZonedDateTime.getTimeInMillis()).isEqualTo(gcDateTime.getTimeInMillis());
+
+        // Assert GregorianCalendar from offsetDateTime has same Offset and Millis
+        assertThat(gcOffsetDateTime.getTimeInMillis()).isEqualTo(gcDateTime.getTimeInMillis());
+        assertThat(gcOffsetDateTime.getTimeZone().getOffset(gcOffsetDateTime.getTimeInMillis())).isEqualTo(gcDateTime.getTimeZone().getOffset(gcDateTime.getTimeInMillis()));
+
+    }
+
+    @Test
+    void toTimeOfDay() {
+
+        DateTime dateTime = DateTime.now();
+        ZonedDateTime zonedDateTime = equivalentZonedDateTime(dateTime);
+        OffsetDateTime offsetDateTime = zonedDateTime.toOffsetDateTime();
+
+        TimeOfDay timeOfDay = dateTime.toTimeOfDay();
+
+        LocalTime zdtLocalTime = zonedDateTime.toLocalTime();
+        LocalTime odtLocalTime = offsetDateTime.toLocalTime();
+
+        JodaTimeToJavaTimeTestUtil.assertSameLocalTime(timeOfDay, zdtLocalTime);
+        JodaTimeToJavaTimeTestUtil.assertSameLocalTime(timeOfDay, odtLocalTime);
+
+
+    }
+
+    @Test
+    void toYearMonthDay() {
+
+        DateTime dateTime = DateTime.now();
+        ZonedDateTime zonedDateTime = equivalentZonedDateTime(dateTime);
+        OffsetDateTime offsetDateTime = zonedDateTime.toOffsetDateTime();
+
+        YearMonthDay yearMonthDay = dateTime.toYearMonthDay();
+
+        LocalDate zdtLocalDate = zonedDateTime.toLocalDate();
+        LocalDate odtLocalDate = offsetDateTime.toLocalDate();
+
+        JodaTimeToJavaTimeTestUtil.assertSameLocalDate(yearMonthDay, zdtLocalDate);
+        JodaTimeToJavaTimeTestUtil.assertSameLocalDate(yearMonthDay, odtLocalDate);
+
+    }
+
+
+}

--- a/example_code/joda-time-to-java-time-examples/src/test/java/util/JodaTimeToJavaTimeTestUtil.java
+++ b/example_code/joda-time-to-java-time-examples/src/test/java/util/JodaTimeToJavaTimeTestUtil.java
@@ -1,0 +1,124 @@
+package util;
+
+import org.joda.time.*;
+
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoField;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+public class JodaTimeToJavaTimeTestUtil {
+
+    public static void assertSameInstantAndZoneId(ReadableDateTime dateTime, ZonedDateTime zonedDateTime) {
+
+        assertSameInstant(dateTime, zonedDateTime.toInstant());
+        assertSameZoneId(dateTime, zonedDateTime);
+
+    }
+
+    public static void assertSameInstantAndOffset(ReadableDateTime dateTime, OffsetDateTime offsetDateTime) {
+        assertSameInstant(dateTime, offsetDateTime.toInstant());
+        assertSameOffset(dateTime, offsetDateTime);
+    }
+
+    public static void assertSameInstant(ReadableInstant dateTime, OffsetDateTime offsetDateTime) {
+        assertSameInstant(dateTime, offsetDateTime.toInstant());
+    }
+
+    public static void assertSameInstant(ReadableInstant dateTime, ZonedDateTime zonedDateTime) {
+        assertSameInstant(dateTime, zonedDateTime.toInstant());
+    }
+
+    public static void assertSameInstant(ReadableInstant dateTime, java.time.Instant instant) {
+
+        // Both should represent the same instant
+        assertThat(dateTime.getMillis()).isEqualTo(instant.toEpochMilli());
+
+    }
+
+    /*
+        Used when we are testing .now(), just check our objects represent an instant within a second of each other
+        Possibly could use AOP to modify clock behaviour. There is a now(Clock clock) method
+        however we are specifically testing the other method signatures of now()
+     */
+    public static void assertCloseToInstant(ReadableInstant dateTime, java.time.Instant instant) {
+
+        // Both should represent almost the same instant
+        assertThat(dateTime.getMillis()).isCloseTo(instant.toEpochMilli(), within(1000L));
+
+    }
+
+    public static void assertSameZoneId(ReadableInstant dateTime, ZonedDateTime zonedDateTime) {
+
+        // Both should be in the same Zone
+        assertThat(dateTime.getZone().getID()).isEqualTo(zonedDateTime.getZone().getId());
+
+    }
+
+    public static void assertSameOffset(ReadableDateTime dateTime, OffsetDateTime offsetDateTime) {
+
+        // Offsets should be the same. Use Joda Duration to compare
+        Duration jodaOffset = Duration.ofMillis(dateTime.getZone().getOffset(dateTime));
+        Duration javaOffset = Duration.ofSeconds(offsetDateTime.getOffset().getTotalSeconds());
+
+        assertThat(jodaOffset).isEqualTo(javaOffset);
+
+    }
+
+    public static void assertSameLocalDate(LocalDate jodaLocalDate, java.time.LocalDate javaLocalDate) {
+
+        assertThat(javaLocalDate.getYear()).isEqualTo(jodaLocalDate.getYear());
+        assertThat(javaLocalDate.getMonthValue()).isEqualTo(jodaLocalDate.getMonthOfYear());
+        assertThat(javaLocalDate.getDayOfMonth()).isEqualTo(jodaLocalDate.getDayOfMonth());
+
+    }
+
+    public static void assertSameLocalDate(YearMonthDay yearMonthDay, java.time.LocalDate javaLocalDate) {
+
+        assertThat(javaLocalDate.getYear()).isEqualTo(yearMonthDay.getYear());
+        assertThat(javaLocalDate.getMonthValue()).isEqualTo(yearMonthDay.getMonthOfYear());
+        assertThat(javaLocalDate.getDayOfMonth()).isEqualTo(yearMonthDay.getDayOfMonth());
+
+    }
+
+    public static void assertSameLocalTime(LocalTime jodaLocalTime, java.time.LocalTime javaLocalTime) {
+
+        assertThat(javaLocalTime.getHour()).isEqualTo(jodaLocalTime.getHourOfDay());
+        assertThat(javaLocalTime.getMinute()).isEqualTo(jodaLocalTime.getMinuteOfHour());
+        assertThat(javaLocalTime.getSecond()).isEqualTo(jodaLocalTime.getSecondOfMinute());
+        assertThat(javaLocalTime.get(ChronoField.MILLI_OF_SECOND)).isEqualTo(jodaLocalTime.getMillisOfSecond());
+
+    }
+    public static void assertSameLocalTime(TimeOfDay jodaLocalTime, java.time.LocalTime javaLocalTime) {
+
+        assertThat(javaLocalTime.getHour()).isEqualTo(jodaLocalTime.getHourOfDay());
+        assertThat(javaLocalTime.getMinute()).isEqualTo(jodaLocalTime.getMinuteOfHour());
+        assertThat(javaLocalTime.getSecond()).isEqualTo(jodaLocalTime.getSecondOfMinute());
+        assertThat(javaLocalTime.get(ChronoField.MILLI_OF_SECOND)).isEqualTo(jodaLocalTime.getMillisOfSecond());
+
+    }
+
+    public static void assertSameLocalDateTime(LocalDateTime jodaLocalDateTime, java.time.LocalDateTime javaLocalDateTime) {
+
+        assertSameLocalDate(jodaLocalDateTime.toLocalDate(), javaLocalDateTime.toLocalDate());
+        assertSameLocalTime(jodaLocalDateTime.toLocalTime(), javaLocalDateTime.toLocalTime());
+
+    }
+
+    public static void assertDifferentInstant(ReadableDateTime dateTime, ZonedDateTime zonedDateTime) {
+
+        assertThat(zonedDateTime.toInstant().toEpochMilli()).isNotEqualTo(dateTime.getMillis());
+
+    }
+
+    public static void assertDifferentInstant(ReadableDateTime dateTime, OffsetDateTime offsetDateTime) {
+
+        assertThat(offsetDateTime.toInstant().toEpochMilli()).isNotEqualTo(dateTime.getMillis());
+
+    }
+
+
+}

--- a/example_code/joda-time-to-java-time-examples/src/test/java/util/JodaTimeToJavaTimeTestUtil.java
+++ b/example_code/joda-time-to-java-time-examples/src/test/java/util/JodaTimeToJavaTimeTestUtil.java
@@ -68,7 +68,7 @@ public class JodaTimeToJavaTimeTestUtil {
 
     }
 
-    public static void assertSameLocalDate(LocalDate jodaLocalDate, java.time.LocalDate javaLocalDate) {
+    public static void assertSameLocalDate(org.joda.time.LocalDate jodaLocalDate, java.time.LocalDate javaLocalDate) {
 
         assertThat(javaLocalDate.getYear()).isEqualTo(jodaLocalDate.getYear());
         assertThat(javaLocalDate.getMonthValue()).isEqualTo(jodaLocalDate.getMonthOfYear());

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-isAfterNow.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-isAfterNow.yaml
@@ -1,0 +1,28 @@
+id: scw:java.time:Joda-Time:DateTime-isAfterNow
+version: 10
+metadata:
+  name: Rewrite isAfterNow to java.time equivalent
+  shortDescription: Rewrite isAfterNow to java.time equivalent
+  level: warning
+  language: java
+  enabled: true
+  comment: |
+    Joda-Time's DateTime class provided an isAfterNow method to conveniently check if the datetime is after the current Instant in time.
+    This method is not available in java.time, but you can acheive the same result by using myZonedDateTime.isAfter(ZonedDateTime.now()) or myOffsetDateTime.isAfter(OffsetDateTime.now()).
+
+    This recipe is designed to match on broken code as part of an overall Joda-Time to java.time migration. The method that is being searched for does not actually exist on ZoneDateTime/OffsetDateTime.
+    After migrating a DateTime instance to a ZoneDateTime or OffsetDateTime, subsequent calls may be made to methods that existed for DateTime, but no longer exist for ZonedDateTime/OffsetDateTime.
+    This recipe matches on the methodname that no longer exists, and suggests an equivalent rewrite that will work for java.time.
+  descriptionFile: descriptions/datetime.html
+  tags: framework specific;java.time;Joda-Time;quality
+search:
+  methodcall:
+    name: isAfterNow
+    anyOf:
+    - type: java.time.OffsetDateTime
+    - type: java.time.ZonedDateTime
+availableFixes:
+- name: Rewrite to isAfter(<type>.now())
+  actions:
+  - rewrite:
+      to: '{{{ qualifier }}}.isAfter({{{ qualifier.type }}}.now())'

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-isBeforeNow.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-isBeforeNow.yaml
@@ -1,0 +1,28 @@
+id: scw:java.time:Joda-Time:DateTime-isBeforeNow
+version: 10
+metadata:
+  name: Rewrite isBeforeNow to java.time equivalent
+  shortDescription: Rewrite isBeforeNow to java.time equivalent
+  level: warning
+  language: java
+  enabled: true
+  comment: |
+    Joda-Time's DateTime class provided an isBeforeNow method to conveniently check if the datetime is before the current Instant in time.
+    This method is not available in java.time, but you can acheive the same result by using myZonedDateTime.isBefore(ZonedDateTime.now()) or myOffsetDateTime.isBefore(OffsetDateTime.now()).
+
+    This recipe is designed to match on broken code as part of an overall Joda-Time to java.time migration. The method that is being searched for does not actually exist on ZoneDateTime/OffsetDateTime.
+    After migrating a DateTime instance to a ZoneDateTime or OffsetDateTime, subsequent calls may be made to methods that existed for DateTime, but no longer exist for ZonedDateTime/OffsetDateTime.
+    This recipe matches on the methodname that no longer exists, and suggests an equivalent rewrite that will work for java.time.
+  descriptionFile: descriptions/datetime.html
+  tags: framework specific;java.time;Joda-Time;quality
+search:
+  methodcall:
+    name: isBeforeNow
+    anyOf:
+    - type: java.time.OffsetDateTime
+    - type: java.time.ZonedDateTime
+availableFixes:
+- name: Rewrite to isBefore(<type>.now())
+  actions:
+  - rewrite:
+      to: '{{{ qualifier }}}.isBefore({{{ qualifier.type }}}.now())'

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-migrate-parameter.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-migrate-parameter.yaml
@@ -1,0 +1,28 @@
+id: scw:java.time:Joda-Time:DateTime-migrate-parameter
+version: 10
+metadata:
+  name: Migrate DateTime parameter to java.time.ZonedDateTime or java.time.OffsetDateTime
+  shortDescription: Migrate DateTime parameter to java.time.ZonedDateTime or java.time.OffsetDateTime
+  level: warning
+  language: java
+  enabled: true
+  comment: |
+    This recipe looks for parameters that are defined as org.joda.time.DateTime and provides fixes to migrate these to java.time ZonedDateTime and OffsetDateTime.
+    This is intended to be used as part of an overall migration from Joda-Time to java.time.
+
+    After migrating these parameters to a java.time equivalent, subsequent method calls and usages of the parameter may become invalid.
+    Further Sensei recipes are available to help resolve many of these invalid usages.
+  descriptionFile: descriptions/datetime.html
+  tags: framework specific;java.time;Joda-Time;quality
+search:
+  parameter:
+    type: org.joda.time.DateTime
+availableFixes:
+- name: Migrate parameter to java.time.ZonedDateTime
+  actions:
+  - changeType:
+      type: java.time.ZonedDateTime
+- name: Migrate parameter to java.time.OffsetDateTime
+  actions:
+  - changeType:
+      type: java.time.OffsetDateTime

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-minus-long.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-minus-long.yaml
@@ -1,0 +1,38 @@
+id: scw:java.time:Joda-Time:DateTime-minus-long
+version: 10
+metadata:
+  name: Rewrite minus(long) method call to java.time equivalent
+  shortDescription: Rewrite minus(long) method call to java.time equivalent
+  level: warning
+  language: java
+  enabled: true
+  comment: |
+    Joda-Time's DateTime class provided a minus(long) method to create a new DateTime object by subtracting milliseconds from an existing DateTime object.
+    This method is not available in java.time, but you can acheive the same result by using minus(long, ChronoUnit.MILLIS)
+
+    This recipe is designed to match on broken code as part of an overall Joda-Time to java.time migration. The method that is being searched for does not actually exist on ZoneDateTime/OffsetDateTime.
+    After migrating a DateTime instance to a ZoneDateTime or OffsetDateTime, subsequent calls may be made to methods that existed for DateTime, but no longer exist for ZonedDateTime/OffsetDateTime.
+    This recipe matches on the methodname that no longer exists, and suggests an equivalent rewrite that will work for java.time.
+  descriptionFile: descriptions/datetime.html
+  tags: framework specific;java.time;Joda-Time;quality
+search:
+  methodcall:
+    args:
+      1:
+        anyOf:
+        - type: long
+        - type: java.lang.Long
+        - type: int
+        - type: java.lang.Integer
+    argCount: 1
+    name: minus
+    anyOf:
+    - type: java.time.ZonedDateTime
+    - type: java.time.OffsetDateTime
+availableFixes:
+- name: 'Rewrite minus(long) to java.time equivalent: minus(value, ChronoUnit.MILLIS)'
+  actions:
+  - rewrite:
+      to: '{{{ qualifier }}}.minus({{{ arguments.0 }}}, java.time.temporal.ChronoUnit.MILLIS)'
+  - modifyAssignedVariable:
+      type: '{{{ qualifier.type }}}'

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-plus-long.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-plus-long.yaml
@@ -1,0 +1,38 @@
+id: scw:java.time:Joda-Time:DateTime-plus-long
+version: 10
+metadata:
+  name: Rewrite DateTime plus(long) to java.time equivalent
+  shortDescription: Rewrite DateTime plus(long) to java.time equivalent
+  level: warning
+  language: java
+  enabled: true
+  comment: |
+    Joda-Time's DateTime class provided a plus(long) method to create a new DateTime object by adding milliseconds to an existing DateTime object.
+    This method is not available in java.time, but you can acheive the same result by using plus(long, ChronoUnit.MILLIS)
+
+    This recipe is designed to match on broken code as part of an overall Joda-Time to java.time migration. The method that is being searched for does not actually exist on ZoneDateTime/OffsetDateTime.
+    After migrating a DateTime instance to a ZoneDateTime or OffsetDateTime, subsequent calls may be made to methods that existed for DateTime, but no longer exist for ZonedDateTime/OffsetDateTime.
+    This recipe matches on the methodname that no longer exists, and suggests an equivalent rewrite that will work for java.time.
+  descriptionFile: descriptions/datetime.html
+  tags: framework specific;java.time;Joda-Time;quality
+search:
+  methodcall:
+    args:
+      1:
+        anyOf:
+        - type: long
+        - type: java.lang.Long
+        - type: int
+        - type: java.lang.Integer
+    argCount: 1
+    name: plus
+    anyOf:
+    - type: java.time.ZonedDateTime
+    - type: java.time.OffsetDateTime
+availableFixes:
+- name: 'Rewrite plus(long) to java.time equivalent: plus(value, ChronoUnit.MILLIS)'
+  actions:
+  - rewrite:
+      to: '{{{ qualifier }}}.plus({{{ arguments.0 }}}, java.time.temporal.ChronoUnit.MILLIS)'
+  - modifyAssignedVariable:
+      type: '{{{ qualifier.type }}}'

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-toDate.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-toDate.yaml
@@ -1,0 +1,28 @@
+id: scw:java.time:Joda-Time:DateTime-toDate
+version: 10
+metadata:
+  name: Rewrite toDate() to java.time equivalent
+  shortDescription: Rewrite toDate() to java.time equivalent
+  level: warning
+  language: java
+  enabled: true
+  comment: |
+    Joda-Time's DateTime class provided a toDate() method to create a java.util.Date from an existing DateTime.
+    In java.time this method is not available, however you can use the .from(Instant) method on java.util.Date to achieve the same result.
+
+    This recipe is designed to match on broken code as part of an overall Joda-Time to java.time migration. The method that is being searched for does not actually exist on ZoneDateTime/OffsetDateTime.
+    After migrating a DateTime instance to a ZoneDateTime or OffsetDateTime, subsequent calls may be made to methods that existed for DateTime, but no longer exist for ZonedDateTime/OffsetDateTime.
+    This recipe matches on the methodname that no longer exists, and suggests an equivalent rewrite that will work for java.time.
+  descriptionFile: descriptions/datetime.html
+  tags: java.time;framework specific;Joda-Time;quality
+search:
+  methodcall:
+    name: toDate
+    anyOf:
+    - type: java.time.ZonedDateTime
+    - type: java.time.OffsetDateTime
+availableFixes:
+- name: Rewrite to Date.from(Instant)
+  actions:
+  - rewrite:
+      to: java.util.Date.from({{{ qualifier }}}.toInstant())

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-toDateMidnight.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-toDateMidnight.yaml
@@ -1,0 +1,49 @@
+id: scw:java.time:Joda-Time:DateTime-toDateMidnight
+version: 10
+metadata:
+  name: Rewrite toDateMidnight() to java.time equivalent
+  shortDescription: Rewrite toDateMidnight() to java.time equivalent
+  level: warning
+  language: java
+  enabled: true
+  comment: |-
+    Joda-Time's DateTime class provided a toDateMidnight() method to create a DateMidnight object from an existing DateTime.
+    The concept of DateMidnight was deprecated within Joda-Time, along with the toDateMidnight() method too.
+    This recipe is supplied to provide a migration in the case where the code-base is still using this deprecated method.
+    There is no DateMidnight class in java.time, however the concept of DateMidnight was consider to be the same as the 'start of Day', so we can provide an equivalent to construct a ZonedDateTime/OffsetDateTime at the start of the day.
+
+    This recipe is designed to match on broken code as part of an overall Joda-Time to java.time migration. The method that is being searched for does not actually exist on ZoneDateTime/OffsetDateTime.
+    After migrating a DateTime instance to a ZoneDateTime or OffsetDateTime, subsequent calls may be made to methods that existed for DateTime, but no longer exist for ZonedDateTime/OffsetDateTime.
+    This recipe matches on the methodname that no longer exists, and suggests an equivalent rewrite that will work for java.time.
+  descriptionFile: descriptions/datetime.html
+  tags: framework specific;java.time;Joda-Time;quality
+search:
+  methodcall:
+    argCount: 0
+    name: toDateMidnight
+    anyOf:
+    - type: java.time.ZonedDateTime
+    - type: java.time.OffsetDateTime
+availableFixes:
+- name: Rewrite using toLocalDate().atStartOfDay(ZoneId)
+  availableIf:
+    markedElement:
+      is:
+        methodcall:
+          type: java.time.ZonedDateTime
+  actions:
+  - rewrite:
+      to: '{{{ qualifier }}}.toLocalDate().atStartOfDay({{{ qualifier }}}.getZone())'
+  - modifyAssignedVariable:
+      type: java.time.ZonedDateTime
+- name: Rewrite using toLocalDate().atStartOfDay().atOffset(ZoneOffset)
+  availableIf:
+    markedElement:
+      is:
+        methodcall:
+          type: java.time.OffsetDateTime
+  actions:
+  - rewrite:
+      to: '{{{ qualifier }}}.toLocalDate().atStartOfDay().atOffset({{{ qualifier }}}.getOffset())'
+  - modifyAssignedVariable:
+      type: java.time.OffsetDateTime

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-toDateMidnight.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-toDateMidnight.yaml
@@ -7,14 +7,22 @@ metadata:
   language: java
   enabled: true
   comment: |-
-    Joda-Time's DateTime class provided a toDateMidnight() method to create a DateMidnight object from an existing DateTime.
-    The concept of DateMidnight was deprecated within Joda-Time, along with the toDateMidnight() method too.
-    This recipe is supplied to provide a migration in the case where the code-base is still using this deprecated method.
-    There is no DateMidnight class in java.time, however the concept of DateMidnight was consider to be the same as the 'start of Day', so we can provide an equivalent to construct a ZonedDateTime/OffsetDateTime at the start of the day.
+    Joda-Time's DateTime class provided a toDateMidnight() method to create a
+    DateMidnight object from an existing DateTime. The concept of DateMidnight was
+    deprecated within Joda-Time, along with the toDateMidnight() method too.
+    This recipe is supplied to provide a migration in the case where the code-base
+    is still using this deprecated method. There is no DateMidnight class in
+    java.time, however the concept of DateMidnight was consider to be the same as
+    the 'start of Day'. We can provide an equivalent to construct a ZonedDateTime
+    or OffsetDateTime at the start of the day.
 
-    This recipe is designed to match on broken code as part of an overall Joda-Time to java.time migration. The method that is being searched for does not actually exist on ZoneDateTime/OffsetDateTime.
-    After migrating a DateTime instance to a ZoneDateTime or OffsetDateTime, subsequent calls may be made to methods that existed for DateTime, but no longer exist for ZonedDateTime/OffsetDateTime.
-    This recipe matches on the methodname that no longer exists, and suggests an equivalent rewrite that will work for java.time.
+    This recipe is designed to match on broken code as part of an overall Joda-Time
+    to java.time migration. The method that is being searched for does not actually
+    exist on ZoneDateTime/OffsetDateTime. After migrating a DateTime instance to a
+    ZoneDateTime or OffsetDateTime, subsequent calls may be made to methods that
+    existed for DateTime, but no longer exist for ZonedDateTime/OffsetDateTime.
+    This recipe matches on the methodname that no longer exists, and suggests an
+    equivalent rewrite that will work for java.time.
   descriptionFile: descriptions/datetime.html
   tags: framework specific;java.time;Joda-Time;quality
 search:

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-toDateTime-DateTimeZone.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-toDateTime-DateTimeZone.yaml
@@ -1,0 +1,69 @@
+id: scw:java.time:Joda-Time:Datetime-toDateTime-DateTimeZone
+version: 10
+metadata:
+  name: Rewrite toDateTime(DateTimeZone) to java.time equivalent
+  shortDescription: Rewrite toDateTime(DateTimeZone) to java.time equivalent
+  level: warning
+  language: java
+  enabled: true
+  comment: |
+    Joda-Time's DateTime class provided a toDateTime(DateTimeZone) and toMutableDateTime(DateTimeZone) methods to create a new DateTime based upon the same instant as the existing DateTime, but in a different TimeZone.
+    In java.time this method is different depending on whether you are using ZonedDateTime or OffsetDateTime. Additionally in OffsetDateTime, you have an additional option if your ZoneId is actually a ZoneOffset. This recipe provides fixes to rewrite the toDateTime(DateTimeZone) methodcall to the new methods.
+    The DateTimeZone argument must first be migrated to ZoneId or ZoneOffset before this recipe will match.
+    MutableDateTime is not supported in java.time, so the closest equivalent for toMutableDateTime(DateTimeZone) is to use the same fixes for toDateTime(DateTimeZone). Any further attempted mutable operations will need to be migrated separately after using this recipe.
+
+    This recipe is designed to match on broken code as part of an overall Joda-Time to java.time migration. The method that is being searched for does not actually exist on ZoneDateTime/OffsetDateTime.
+    After migrating a DateTime instance to a ZoneDateTime or OffsetDateTime, subsequent calls may be made to methods that existed for DateTime, but no longer exist for ZonedDateTime/OffsetDateTime.
+    This recipe matches on the methodname that no longer exists, and suggests an equivalent rewrite that will work for java.time.
+  descriptionFile: descriptions/datetime.html
+  tags: framework specific;java.time;Joda-Time;quality
+search:
+  methodcall:
+    args:
+      1:
+        type: java.time.ZoneId
+    allOf:
+    - anyOf:
+      - name: toDateTime
+      - name: toMutableDateTime
+    - anyOf:
+      - type: java.time.OffsetDateTime
+      - type: java.time.ZonedDateTime
+    argCount: 1
+availableFixes:
+- name: 'Rewrite to java.time equivalent: atZoneSameInstant(ZoneId)'
+  availableIf:
+    markedElement:
+      is:
+        methodcall:
+          type: java.time.OffsetDateTime
+  actions:
+  - rewrite:
+      to: '{{{ qualifier }}}.atZoneSameInstant({{{ arguments.0 }}})'
+  - modifyAssignedVariable:
+      type: java.time.ZonedDateTime
+- name: Rewrite to java.time equivalent withZoneSameInstant(ZoneId)
+  availableIf:
+    markedElement:
+      is:
+        methodcall:
+          type: java.time.ZonedDateTime
+  actions:
+  - rewrite:
+      to: '{{{ qualifier }}}.withZoneSameInstant({{{ arguments.0 }}})'
+  - modifyAssignedVariable:
+      type: java.time.ZonedDateTime
+- name: Rewrite to java.time equivalent withOffsetSameInstant(ZoneOffset)
+  availableIf:
+    markedElement:
+      is:
+        methodcall:
+          args:
+            1:
+              type: java.time.ZoneOffset
+          type: java.time.OffsetDateTime
+  actions:
+  - rewrite:
+      to: '{{{ qualifier }}}.withOffsetSameInstant({{{ arguments.0 }}})'
+  - modifyAssignedVariable:
+      type: java.time.OffsetDateTime

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-toDateTime-DateTimeZone.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-toDateTime-DateTimeZone.yaml
@@ -7,14 +7,26 @@ metadata:
   language: java
   enabled: true
   comment: |
-    Joda-Time's DateTime class provided a toDateTime(DateTimeZone) and toMutableDateTime(DateTimeZone) methods to create a new DateTime based upon the same instant as the existing DateTime, but in a different TimeZone.
-    In java.time this method is different depending on whether you are using ZonedDateTime or OffsetDateTime. Additionally in OffsetDateTime, you have an additional option if your ZoneId is actually a ZoneOffset. This recipe provides fixes to rewrite the toDateTime(DateTimeZone) methodcall to the new methods.
-    The DateTimeZone argument must first be migrated to ZoneId or ZoneOffset before this recipe will match.
-    MutableDateTime is not supported in java.time, so the closest equivalent for toMutableDateTime(DateTimeZone) is to use the same fixes for toDateTime(DateTimeZone). Any further attempted mutable operations will need to be migrated separately after using this recipe.
+    Joda-Time's DateTime class provided a toDateTime(DateTimeZone) and
+    toMutableDateTime(DateTimeZone) methods to create a new DateTime based upon the
+    same instant as the existing DateTime, but in a different TimeZone.
+    In java.time this method is different depending on whether you are using
+    ZonedDateTime or OffsetDateTime. Additionally in OffsetDateTime, you have an
+    additional option if your ZoneId is actually a ZoneOffset.
+    This recipe provides fixes to rewrite the toDateTime(DateTimeZone) methodcall to
+    the new methods. The DateTimeZone argument must first be migrated to ZoneId or
+    ZoneOffset before this recipe will match. MutableDateTime is not supported in
+    java.time, so the closest equivalent for toMutableDateTime(DateTimeZone) is to
+    use the same fixes for toDateTime(DateTimeZone). Any further attempted mutable
+    operations will need to be migrated separately after using this recipe.
 
-    This recipe is designed to match on broken code as part of an overall Joda-Time to java.time migration. The method that is being searched for does not actually exist on ZoneDateTime/OffsetDateTime.
-    After migrating a DateTime instance to a ZoneDateTime or OffsetDateTime, subsequent calls may be made to methods that existed for DateTime, but no longer exist for ZonedDateTime/OffsetDateTime.
-    This recipe matches on the methodname that no longer exists, and suggests an equivalent rewrite that will work for java.time.
+    This recipe is designed to match on broken code as part of an overall Joda-Time
+    to java.time migration. The method that is being searched for does not actually
+    exist on ZoneDateTime/OffsetDateTime. After migrating a DateTime instance to a
+    ZoneDateTime or OffsetDateTime, subsequent calls may be made to methods that
+    existed for DateTime, but no longer exist for ZonedDateTime/OffsetDateTime.
+    This recipe matches on the methodname that no longer exists, and suggests an
+    equivalent rewrite that will work for java.time.
   descriptionFile: descriptions/datetime.html
   tags: framework specific;java.time;Joda-Time;quality
 search:

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-toDateTime.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-toDateTime.yaml
@@ -7,13 +7,22 @@ metadata:
   language: java
   enabled: true
   comment: |
-    Joda-Time's DateTime class provided a toDateTime() method which simply returned 'this'.
-    java.time does not have a toDateTime() method but we can provide an equivalent by simply removing the method call.
-    Additionally a toMutableDateTime() method was available which performed a similar operation, returning a MutableDateTime instead. Since MutableDateTime is not available in java.time, the closest migration is to switch to the immutable objects available in java.time. Any subsequent attempted mutable operations will need to be migrated separately after using this recipe.
+    Joda-Time's DateTime class provided a toDateTime() method which simply returned
+    'this'. java.time does not have a toDateTime() method but we can provide an
+    equivalent by simply removing the method call.
+    Additionally a toMutableDateTime() method was available which performed a
+    similar operation, returning a MutableDateTime instead. Since MutableDateTime is
+    not available in java.time, the closest migration is to switch to the immutable
+    objects available in java.time. Any subsequent attempted mutable operations will
+    need to be migrated separately after using this recipe.
 
-    This recipe is designed to match on broken code as part of an overall Joda-Time to java.time migration. The method that is being searched for does not actually exist on ZoneDateTime/OffsetDateTime.
-    After migrating a DateTime instance to a ZoneDateTime or OffsetDateTime, subsequent calls may be made to methods that existed for DateTime, but no longer exist for ZonedDateTime/OffsetDateTime.
-    This recipe matches on the methodname that no longer exists, and suggests an equivalent rewrite that will work for java.time.
+    This recipe is designed to match on broken code as part of an overall Joda-Time
+    to java.time migration. The method that is being searched for does not actually
+    exist on ZoneDateTime/OffsetDateTime. After migrating a DateTime instance to a
+    ZoneDateTime or OffsetDateTime, subsequent calls may be made to methods that
+    existed for DateTime, but no longer exist for ZonedDateTime/OffsetDateTime.
+    This recipe matches on the methodname that no longer exists, and suggests an
+    equivalent rewrite that will work for java.time.
   descriptionFile: descriptions/datetime.html
   tags: java.time;framework specific;Joda-Time;quality
 search:

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-toDateTime.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-toDateTime.yaml
@@ -1,0 +1,36 @@
+id: scw:java.time:Joda-Time:DateTime-toDateTime
+version: 10
+metadata:
+  name: Remove obsolete toDateTime method call
+  shortDescription: Remove obsolete toDateTime method call
+  level: warning
+  language: java
+  enabled: true
+  comment: |
+    Joda-Time's DateTime class provided a toDateTime() method which simply returned 'this'.
+    java.time does not have a toDateTime() method but we can provide an equivalent by simply removing the method call.
+    Additionally a toMutableDateTime() method was available which performed a similar operation, returning a MutableDateTime instead. Since MutableDateTime is not available in java.time, the closest migration is to switch to the immutable objects available in java.time. Any subsequent attempted mutable operations will need to be migrated separately after using this recipe.
+
+    This recipe is designed to match on broken code as part of an overall Joda-Time to java.time migration. The method that is being searched for does not actually exist on ZoneDateTime/OffsetDateTime.
+    After migrating a DateTime instance to a ZoneDateTime or OffsetDateTime, subsequent calls may be made to methods that existed for DateTime, but no longer exist for ZonedDateTime/OffsetDateTime.
+    This recipe matches on the methodname that no longer exists, and suggests an equivalent rewrite that will work for java.time.
+  descriptionFile: descriptions/datetime.html
+  tags: java.time;framework specific;Joda-Time;quality
+search:
+  methodcall:
+    allOf:
+    - anyOf:
+      - name: toDateTime
+      - name: toDateTimeISO
+      - name: toMutableDateTime
+    - anyOf:
+      - type: java.time.ZonedDateTime
+      - type: java.time.OffsetDateTime
+    argCount: 0
+availableFixes:
+- name: Remove obsolete toDateTime() method call
+  actions:
+  - rewrite:
+      to: '{{{ qualifier }}}'
+  - modifyAssignedVariable:
+      type: '{{{ qualifier.type }}}'

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-toGregorianCalendar.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-toGregorianCalendar.yaml
@@ -1,0 +1,42 @@
+id: scw:java.time:Joda-Time:DateTime-toGregorianCalendar
+version: 10
+metadata:
+  name: Rewrite toGregorianCalendar to GregorianCalendar.from(ZonedDateTime)
+  shortDescription: Rewrite toGregorianCalendar to GregorianCalendar.from(ZonedDateTime)
+  level: warning
+  language: java
+  enabled: true
+  comment: |
+    Joda-Time's DateTime class provided a toGregorianCalendar() method to create a java.util.GregorianCalendar from an existing DateTime.
+    In java.time this method is not available, however you can use the .from(ZonedDateTime) method on java.util.GregorianCalendar to achieve the same result.
+
+    This recipe is designed to match on broken code as part of an overall Joda-Time to java.time migration. The method that is being searched for does not actually exist on ZoneDateTime/OffsetDateTime.
+    After migrating a DateTime instance to a ZoneDateTime or OffsetDateTime, subsequent calls may be made to methods that existed for DateTime, but no longer exist for ZonedDateTime/OffsetDateTime.
+    This recipe matches on the methodname that no longer exists, and suggests an equivalent rewrite that will work for java.time.
+  descriptionFile: descriptions/datetime.html
+  tags: java.time;framework specific;Joda-Time;quality
+search:
+  methodcall:
+    name: toGregorianCalendar
+    anyOf:
+    - type: java.time.ZonedDateTime
+    - type: java.time.OffsetDateTime
+availableFixes:
+- name: Rewrite to GregorianCalendar.from(zonedDateTime)
+  availableIf:
+    markedElement:
+      is:
+        methodcall:
+          type: java.time.ZonedDateTime
+  actions:
+  - rewrite:
+      to: java.util.GregorianCalendar.from({{{ qualifier }}})
+- name: Rewrite to GregorianCalendar.from(zonedDateTime)
+  availableIf:
+    markedElement:
+      is:
+        methodcall:
+          type: java.time.OffsetDateTime
+  actions:
+  - rewrite:
+      to: java.util.GregorianCalendar.from({{{ qualifier }}}.toZonedDateTime())

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-toString.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-toString.yaml
@@ -1,0 +1,27 @@
+id: scw:java.time:Joda-Time:DateTime-toString
+version: 10
+metadata:
+  name: DateTime toString() format has changed from Joda-Time to java.time
+  shortDescription: DateTime toString() format has changed from Joda-Time to java.time
+  level: warning
+  language: java
+  enabled: true
+  comment: |-
+    In Joda-Time the DateTime toString() method produced a consistent output format. After migrating to java.time the output is slightly different for both ZonedDateTime and OffsetDateTime.
+    If the output is being used in any sort of data exchange, then it is possible to maintain the same format as previously used in java.time.
+    This recipe is provided to highlight this difference, and provide a fix to rewrite the toString() call so that it will produce the same output as before.
+    If the new java.time toString() output format is acceptable, then this recipe should be disabled so that it will no longer highlight this difference.
+  descriptionFile: descriptions/toString.html
+  tags: java.time;framework specific;Joda-Time;quality
+search:
+  methodcall:
+    argCount: 0
+    name: toString
+    anyOf:
+    - type: java.time.ZonedDateTime
+    - type: java.time.OffsetDateTime
+availableFixes:
+- name: 'To preserve exact format as Joda-Time: rewrite to .format(DateTimeFormatter.ofPattern("uuuu-MM-dd''T''HH:mm:ss.SSSXXX"))'
+  actions:
+  - rewrite:
+      to: '{{{ qualifier }}}.format(java.time.format.DateTimeFormatter.ofPattern("uuuu-MM-dd''T''HH:mm:ss.SSSXXX"))'

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-toTimeOfDay.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-toTimeOfDay.yaml
@@ -1,0 +1,33 @@
+id: scw:java.time:Joda-Time:DateTime-toTimeOfDay
+version: 10
+metadata:
+  name: Rewrite toTimeOfDay() to toLocalTime()
+  shortDescription: Rewrite toTimeOfDay() to toLocalTime()
+  level: warning
+  language: java
+  enabled: true
+  comment: |-
+    Joda-Time originally included a 'TimeOfDay' class which has been deprecated in favour of LocalTime.
+    The DateTime class had a deprecated method toTimeOfDay() to create a TimeOfDay object from an existing DateTime.
+    This recipe is supplied to provide a migration in the case where the code-base is still using this deprecated method.
+    There is no TimeOfDay class in java.time, however the concept is represented by LocalTime, so we can use toLocalTime() to achieve the same result.
+
+    This recipe is designed to match on broken code as part of an overall Joda-Time to java.time migration. The method that is being searched for does not actually exist on ZoneDateTime/OffsetDateTime.
+    After migrating a DateTime instance to a ZoneDateTime or OffsetDateTime, subsequent calls may be made to methods that existed for DateTime, but no longer exist for ZonedDateTime/OffsetDateTime.
+    This recipe matches on the methodname that no longer exists, and suggests an equivalent rewrite that will work for java.time.
+  descriptionFile: descriptions/datetime.html
+  tags: java.time;framework specific;Joda-Time;quality
+search:
+  methodcall:
+    argCount: 0
+    name: toTimeOfDay
+    anyOf:
+    - type: java.time.ZonedDateTime
+    - type: java.time.OffsetDateTime
+availableFixes:
+- name: Rewrite method call to java.time equivalent toLocalTime()
+  actions:
+  - rewrite:
+      to: '{{{ qualifier }}}.toLocalTime()'
+  - modifyAssignedVariable:
+      type: java.time.LocalTime

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-toYearMonthDay.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-toYearMonthDay.yaml
@@ -1,0 +1,33 @@
+id: scw:java.time:Joda-Time:DateTime-toYearMonthDay
+version: 10
+metadata:
+  name: Rewrite toYearMonthDay() to toLocalDate()
+  shortDescription: Rewrite toYearMonthDay() to toLocalDate()
+  level: warning
+  language: java
+  enabled: true
+  comment: |
+    Joda-Time originally included a 'YearMonthDay' class which has been deprecated in favour of LocalDate.
+    The DateTime class had a deprecated method toYearMonthDay() to create a YearMonthDay object from an existing DateTime.
+    This recipe is supplied to provide a migration in the case where the code-base is still using this deprecated method.
+    There is no YearMonthDay class in java.time, however the concept is represented by LocalDate, so we can use toLocalDate() to achieve the same result.
+
+    This recipe is designed to match on broken code as part of an overall Joda-Time to java.time migration. The method that is being searched for does not actually exist on ZoneDateTime/OffsetDateTime.
+    After migrating a DateTime instance to a ZoneDateTime or OffsetDateTime, subsequent calls may be made to methods that existed for DateTime, but no longer exist for ZonedDateTime/OffsetDateTime.
+    This recipe matches on the methodname that no longer exists, and suggests an equivalent rewrite that will work for java.time.
+  descriptionFile: descriptions/datetime.html
+  tags: java.time;framework specific;Joda-Time;quality
+search:
+  methodcall:
+    argCount: 0
+    name: toYearMonthDay
+    anyOf:
+    - type: java.time.ZonedDateTime
+    - type: java.time.OffsetDateTime
+availableFixes:
+- name: Rewrite method call to java.time equivalent toLocalDate()
+  actions:
+  - rewrite:
+      to: '{{{ qualifier }}}.toLocalDate()'
+  - modifyAssignedVariable:
+      type: java.time.LocalDate

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-withZone.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-withZone.yaml
@@ -1,0 +1,64 @@
+id: scw:java.time:Joda-Time:DateTime-withZone
+version: 10
+metadata:
+  name: Rewrite DateTime withZone to java.time equivalent
+  shortDescription: Rewrite DateTime withZone to java.time equivalent
+  level: warning
+  language: java
+  enabled: true
+  comment: |
+    Joda-Time's DateTime class provided a withZone method to create a new DateTime object from an existing DateTime, using the same Instant but in a different Zone.
+    In java.time, the same behaviour is available however the method names are more specifically named, and slightly different depending on whether you are starting from a ZonedDateTime or OffsetDateTime object.
+
+    This recipe is designed to match on broken code as part of an overall Joda-Time to java.time migration. The method that is being searched for does not actually exist on ZoneDateTime/OffsetDateTime.
+    After migrating a DateTime instance to a ZoneDateTime or OffsetDateTime, subsequent calls may be made to methods that existed for DateTime, but no longer exist for ZonedDateTime/OffsetDateTime.
+    This recipe matches on the methodname that no longer exists, and suggests an equivalent rewrite that will work for java.time.
+  descriptionFile: descriptions/datetime.html
+  tags: framework specific;java.time;Joda-Time;quality
+search:
+  methodcall:
+    args:
+      1:
+        type: java.time.ZoneId
+    argCount: 1
+    name: withZone
+    anyOf:
+    - type: java.time.OffsetDateTime
+    - type: java.time.ZonedDateTime
+availableFixes:
+- name: 'Rewrite withZone to java.time equivalent: atZoneSameInstant'
+  availableIf:
+    markedElement:
+      is:
+        methodcall:
+          type: java.time.OffsetDateTime
+  actions:
+  - rewrite:
+      to: '{{{ qualifier }}}.atZoneSameInstant({{{ arguments.0 }}})'
+  - modifyAssignedVariable:
+      type: java.time.ZonedDateTime
+- name: 'Rewrite withZone to java.time equivalent: withOffsetSameInstant'
+  availableIf:
+    markedElement:
+      is:
+        methodcall:
+          args:
+            1:
+              type: java.time.ZoneOffset
+          type: java.time.OffsetDateTime
+  actions:
+  - rewrite:
+      to: '{{{ qualifier }}}.withOffsetSameInstant({{{ arguments.0 }}})'
+  - modifyAssignedVariable:
+      type: java.time.OffsetDateTime
+- name: 'Rewrite withZone to java.time equivalent: withZoneSameInstant'
+  availableIf:
+    markedElement:
+      is:
+        methodcall:
+          type: java.time.ZonedDateTime
+  actions:
+  - rewrite:
+      to: '{{{ qualifier }}}.withZoneSameInstant({{{ arguments.0 }}})'
+  - modifyAssignedVariable:
+      type: java.time.ZonedDateTime

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-withZoneRetainFields.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-withZoneRetainFields.yaml
@@ -1,0 +1,63 @@
+id: scw:java.time:Joda-Time:DateTime-withZoneRetainFields
+version: 10
+metadata:
+  name: Rewrite DateTime withZoneRetainFields to java.time equivalent
+  shortDescription: Rewrite DateTime withZoneRetainFields to java.time equivalent
+  level: warning
+  language: java
+  enabled: true
+  comment: |-
+    Joda-Time's DateTime class provided a withZoneRetainFields method to create a new DateTime object from an existing DateTime, using the same date and time fields but in a different Zone.
+    In java.time, the same behaviour is available however the method names are more specifically named, and slightly different depending on whether you are starting from a ZonedDateTime or OffsetDateTime object.
+
+    This recipe is designed to match on broken code as part of an overall Joda-Time to java.time migration. The method that is being searched for does not actually exist on ZoneDateTime/OffsetDateTime.
+    After migrating a DateTime instance to a ZoneDateTime or OffsetDateTime, subsequent calls may be made to methods that existed for DateTime, but no longer exist for ZonedDateTime/OffsetDateTime.
+    This recipe matches on the methodname that no longer exists, and suggests an equivalent rewrite that will work for java.time.
+  descriptionFile: descriptions/datetime.html
+  tags: framework specific;java.time;Joda-Time;quality
+search:
+  methodcall:
+    args:
+      1:
+        type: java.time.ZoneId
+    name: withZoneRetainFields
+    anyOf:
+    - type: java.time.OffsetDateTime
+    - type: java.time.ZonedDateTime
+availableFixes:
+- name: 'Rewrite withZoneRetainFields to java.time equivalent: withZoneSameLocal'
+  availableIf:
+    markedElement:
+      is:
+        methodcall:
+          type: java.time.ZonedDateTime
+  actions:
+  - rewrite:
+      to: '{{{ qualifier }}}.withZoneSameLocal({{{ arguments.0 }}})'
+  - modifyAssignedVariable:
+      type: java.time.ZonedDateTime
+- name: 'Rewrite withZoneRetainFields to java.time equivalent: atZoneSimilarLocal'
+  availableIf:
+    markedElement:
+      is:
+        methodcall:
+          type: java.time.OffsetDateTime
+  actions:
+  - modifyAssignedVariable:
+      type: java.time.ZonedDateTime
+  - rewrite:
+      to: '{{{ qualifier }}}.atZoneSimilarLocal({{{ arguments.0 }}})'
+- name: Rewrite withZoneRetainFields to java.time equivalent withOffsetSameLocal
+  availableIf:
+    markedElement:
+      is:
+        methodcall:
+          args:
+            1:
+              type: java.time.ZoneOffset
+          type: java.time.OffsetDateTime
+  actions:
+  - rewrite:
+      to: '{{{ qualifier }}}.withOffsetSameLocal({{{ arguments.0 }}})'
+  - modifyAssignedVariable:
+      type: java.time.OffsetDateTime

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/descriptions/toString.html
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/descriptions/toString.html
@@ -1,0 +1,14 @@
+<html>
+<body>
+
+<h1>toString default format has changed</h1>
+<p>If you are using toString for display purposes, this will not be a problem. 
+However if you are using toString to write to log files, databases etc. where the format is expected to be the same, you will need to migrate this toString() call to a format() call instead</p>
+<p>
+Joda-Time uses the following format in toString for DateTime</p>
+<pre>uuuu-MM-dd'T'HH:mm:ss.SSSXXX</pre>
+
+<p>java.time has a different behaviour, and will output the ZoneID if it is different to the offset.</p>
+
+</body>
+</html>


### PR DESCRIPTION
Closes SEN-2535

This is primarily for the instance methods of DateTime but also includes a recipe for migrating a DateTime parameter.

Co-authored-by: Wander Neto <wneto@securecodewarrior.com>