### PR TITLE
SEN-2564 Add recipes for migrating TestNG assertions to AssertJ

### DIFF
--- a/example_code/assertj/pom.xml
+++ b/example_code/assertj/pom.xml
@@ -46,7 +46,12 @@
             <version>3.20.2</version>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>7.4.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/example_code/assertj/src/test/java/junit/JUnit5Assertions.java
+++ b/example_code/assertj/src/test/java/junit/JUnit5Assertions.java
@@ -5,6 +5,7 @@ import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.ThrowingSupplier;
+import org.testng.AssertJUnit;
 
 import java.util.List;
 import java.util.function.Supplier;
@@ -27,23 +28,27 @@ public class JUnit5Assertions {
         // Should change to: assertThat(actual).isEqualTo(expected);
         Assert.assertArrayEquals(expected, actual);
         Assertions.assertArrayEquals(expected, actual);
+        AssertJUnit.assertArrayEquals(expected, actual);
 
         // Should change to: assertThat(actual).as("message").isEqualTo(expected);
         Assert.assertArrayEquals("message", expected, actual);
         Assertions.assertArrayEquals(expected, actual, "message");
+        AssertJUnit.assertArrayEquals("message", expected, actual);
     }
 
     @Test
     void assertEquals() {
-        // Should change to: assertThat(3).isEqualTo(3);
-        TestCase.assertEquals(3, 3);
-        Assert.assertEquals(3, 3);
-        Assertions.assertEquals(3, 3);
+        // Should change to: assertThat(2 + 1).isEqualTo(3);
+        TestCase.assertEquals(3, 2 + 1);
+        Assert.assertEquals(3, 2 + 1);
+        AssertJUnit.assertEquals(3, 2 + 1);
+        Assertions.assertEquals(3, 2 + 1);
 
-        // Should change to: assertThat(3).as("message").isEqualTo(3);
-        TestCase.assertEquals("message", 3, 3);
-        Assert.assertEquals("message", 3, 3);
-        Assertions.assertEquals(3, 3, "message");
+        // Should change to: assertThat(2 + 1).as("message").isEqualTo(3);
+        TestCase.assertEquals("message", 3, 2 + 1);
+        Assert.assertEquals("message", 3, 2 + 1);
+        AssertJUnit.assertEquals("message", 3, 2 + 1);
+        Assertions.assertEquals(3, 2 + 1, "message");
     }
 
     @Test
@@ -51,11 +56,13 @@ public class JUnit5Assertions {
         // Should change to: assertThat(false).isFalse();
         TestCase.assertFalse(false);
         Assert.assertFalse(false);
+        AssertJUnit.assertFalse(false);
         Assertions.assertFalse(false);
 
         // Should change to: assertThat(false).as("message").isFalse();
         TestCase.assertFalse("message", false);
         Assert.assertFalse("message", false);
+        AssertJUnit.assertFalse("message", false);
         Assertions.assertFalse(false, "message");
     }
 
@@ -64,11 +71,13 @@ public class JUnit5Assertions {
         // Should change to: assertThat(true).isTrue();
         TestCase.assertTrue(true);
         Assert.assertTrue(true);
+        AssertJUnit.assertTrue(true);
         Assertions.assertTrue(true);
 
         // Should change to: assertThat(true).as("message").isTrue();
         TestCase.assertTrue("message", true);
         Assert.assertTrue("message", true);
+        AssertJUnit.assertTrue("message", true);
         Assertions.assertTrue(true, "message");
     }
 
@@ -77,11 +86,13 @@ public class JUnit5Assertions {
         // Should change to: assertThat(nullObject).isNull();
         TestCase.assertNull(nullObject);
         Assert.assertNull(nullObject);
+        AssertJUnit.assertNull(nullObject);
         Assertions.assertNull(nullObject);
 
         // Should change to: assertThat(nullObject).as("message").isNull();
         TestCase.assertNull("message", nullObject);
         Assert.assertNull("message", nullObject);
+        AssertJUnit.assertNull("message", nullObject);
         Assertions.assertNull(nullObject, "message");
     }
 
@@ -90,11 +101,13 @@ public class JUnit5Assertions {
         // Should change to: assertThat(notNull).isNotNull();
         TestCase.assertNotNull(notNull);
         Assert.assertNotNull(notNull);
+        AssertJUnit.assertNotNull(notNull);
         Assertions.assertNotNull(notNull);
 
         // Should change to: assertThat(notNull).as("message").isNotNull();
         TestCase.assertNotNull("message", notNull);
         Assert.assertNotNull("message", notNull);
+        AssertJUnit.assertNotNull("message", notNull);
         Assertions.assertNotNull(notNull, "message");
     }
 
@@ -103,11 +116,13 @@ public class JUnit5Assertions {
         // Should change to: assertThat(actualA).isSameAs(a);
         TestCase.assertSame(a, actualA);
         Assert.assertSame(a, actualA);
+        AssertJUnit.assertSame(a, actualA);
         Assertions.assertSame(a, actualA);
 
         // Should change to: assertThat(actualA).as("message").isSameAs(a);
         TestCase.assertSame("message", a, actualA);
         Assert.assertSame("message", a, actualA);
+        AssertJUnit.assertSame("message", a, actualA);
         Assertions.assertSame(a, actualA, "message");
     }
 
@@ -116,11 +131,13 @@ public class JUnit5Assertions {
         // Should change to: assertThat(b).isNotSameAs(a);
         TestCase.assertNotSame(a, b);
         Assert.assertNotSame(a, b);
+        AssertJUnit.assertNotSame(a, b);
         Assertions.assertNotSame(a, b);
 
         // Should change to: assertThat(b).as("message").isNotSameAs(a);
         TestCase.assertNotSame("message", a, b);
         Assert.assertNotSame("message", a, b);
+        AssertJUnit.assertNotSame("message", a, b);
         Assertions.assertNotSame(a, b, "message");
     }
 
@@ -289,6 +306,10 @@ public class JUnit5Assertions {
         Assert.fail();
         Assert.fail("message");
 
+        // TestNG
+        AssertJUnit.fail();
+        AssertJUnit.fail("message");
+
         // JUnit 5
         Assertions.fail();
         Assertions.fail("message");
@@ -305,6 +326,9 @@ public class JUnit5Assertions {
         Assertions.fail(new Throwable());
 
         // should change to these calls respectively:
+        fail("");
+        fail("message");
+
         fail("");
         fail("message");
 

--- a/example_code/assertj/src/test/java/testng/TestNgAssertions.java
+++ b/example_code/assertj/src/test/java/testng/TestNgAssertions.java
@@ -1,0 +1,131 @@
+package testng;
+
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+public class TestNgAssertions {
+
+    private final Object notNull = new Object();
+    private final Object nullObject = null;
+    private final Object a = new Object();
+    private final Object actualA = a;
+    private final Object b = new Object();
+    private final Object[] actual = List.of().toArray();
+    private final Object[] expected = List.of().toArray();
+
+    @Test
+    void ng_assertArrayEquals() {
+        // Should change to: assertThat(actual).isEqualTo(expected);
+        org.testng.Assert.assertEquals(actual, expected);
+
+        // Should change to: assertThat(actual).as("message").isEqualTo(expected);
+        org.testng.Assert.assertEquals(actual, expected, "message");
+    }
+
+    @Test
+    void ng_assertEquals() {
+        // Should change to: assertThat(2 + 1).isEqualTo(3);
+        org.testng.Assert.assertEquals(2 + 1, 3);
+
+        // Should change to: assertThat(2 + 1).as("message").isEqualTo(3);
+        org.testng.Assert.assertEquals(2 + 1, 3, "message");
+    }
+
+    @Test
+    void ng_assertNotEquals() {
+        // Should change to: assertThat(3).isNotEqualTo(4);
+        org.testng.Assert.assertNotEquals(3, 4);
+
+        // Should change to: assertThat(3).as("message").isNotEqualTo(4);
+        org.testng.Assert.assertNotEquals(3, 4, "message");
+    }
+
+    @Test
+    void ng_assertFalse() {
+        // Should change to: assertThat(false).isFalse();
+        org.testng.Assert.assertFalse(false);
+
+        // Should change to: assertThat(false).as("message").isFalse();
+        org.testng.Assert.assertFalse(false, "message");
+    }
+
+    @Test
+    void ng_assertTrue() {
+        // Should change to: assertThat(true).isTrue();
+        org.testng.Assert.assertTrue(true);
+
+        // Should change to: assertThat(true).as("message").isTrue();
+        org.testng.Assert.assertTrue(true, "message");
+    }
+
+    @SuppressWarnings("ConstantConditions")
+    @Test
+    void ng_assertNull() {
+        // Should change to: assertThat(nullObject).isNull();
+        org.testng.Assert.assertNull(nullObject);
+
+        // Should change to: assertThat(nullObject).as("message").isNull();
+        org.testng.Assert.assertNull(nullObject, "message");
+    }
+
+    @Test
+    void ng_assertNotNull() {
+        // Should change to: assertThat(notNull).isNotNull();
+        org.testng.Assert.assertNotNull(notNull);
+
+        // Should change to: assertThat(notNull).as("message").isNotNull();
+        org.testng.Assert.assertNotNull(notNull, "message");
+    }
+
+    @Test
+    void ng_assertSame() {
+        // Should change to: assertThat(actualA).isSameAs(a);
+        org.testng.Assert.assertSame(actualA, a);
+
+        // Should change to: assertThat(actualA).as("message").isSameAs(a);
+        org.testng.Assert.assertSame(actualA, a, "message");
+    }
+
+    @Test
+    void ng_assertNotSame() {
+        // Should change to: assertThat(b).isNotSameAs(a);
+        org.testng.Assert.assertNotSame(b, a);
+
+        // Should change to: assertThat(b).as("message").isNotSameAs(a);
+        org.testng.Assert.assertNotSame(b, a, "message");
+    }
+
+    @Test
+    void ng_assertThrows() {
+        // TestNg assertions like these:
+        org.testng.Assert.assertThrows(Exception.class, () -> {
+            throw new Exception();
+        });
+
+        // should change to either this:
+        org.assertj.core.api.Assertions.assertThatThrownBy(() -> {
+            throw new Exception();
+        }).isInstanceOf(Exception.class);
+
+        // or this:
+        org.assertj.core.api.Assertions.assertThatExceptionOfType(Exception.class)
+                .isThrownBy(() -> {
+                    throw new Exception();
+                });
+
+        // or this:
+        org.assertj.core.api.Assertions.assertThatCode(() -> {
+            throw new Exception();
+        }).isInstanceOf(Exception.class);
+    }
+
+    @Test
+    void ng_testFail() {
+        // should change to org.assertj.core.api.Assertions.fail("");
+        org.testng.Assert.fail();
+
+        // should change to org.assertj.core.api.Assertions.fail("message");
+        org.testng.Assert.fail("message");
+    }
+}

--- a/recipes/Java/AssertJ/From JUnit/JUnit_assertArrayEquals.yaml
+++ b/recipes/Java/AssertJ/From JUnit/JUnit_assertArrayEquals.yaml
@@ -6,7 +6,7 @@ metadata:
   level: warning
   language: java
   enabled: true
-  tags: AssertJ
+  tags: AssertJ; TestNG
 search:
   methodcall:
     argCount: 2
@@ -14,6 +14,7 @@ search:
     anyOf:
     - type: org.junit.Assert
     - type: org.junit.jupiter.api.Assertions
+    - type: org.testng.internal.junit.ArrayAsserts
 availableFixes:
 - doStaticImports: true
   name: Change to assertThat(actualArray).isEqualTo(expectedArray)

--- a/recipes/Java/AssertJ/From JUnit/JUnit_assertArrayEquals_message.yaml
+++ b/recipes/Java/AssertJ/From JUnit/JUnit_assertArrayEquals_message.yaml
@@ -6,7 +6,7 @@ metadata:
   level: warning
   language: java
   enabled: true
-  tags: AssertJ
+  tags: AssertJ; TestNG
 search:
   methodcall:
     argCount: 3
@@ -20,6 +20,10 @@ search:
         3:
           type: String
       type: org.junit.jupiter.api.Assertions
+    - args:
+        1:
+          type: String
+      type: org.testng.internal.junit.ArrayAsserts
 availableFixes:
 - doStaticImports: true
   name: Change to assertThat(actualArray).as(message).isEqualTo(expectedArray)

--- a/recipes/Java/AssertJ/From JUnit/JUnit_assertEquals.yaml
+++ b/recipes/Java/AssertJ/From JUnit/JUnit_assertEquals.yaml
@@ -6,7 +6,7 @@ metadata:
   level: warning
   language: java
   enabled: true
-  tags: AssertJ
+  tags: AssertJ; TestNG
 search:
   methodcall:
     argCount: 2
@@ -16,6 +16,7 @@ search:
     - type: junit.framework.TestCase
     - type: junit.framework.Assert
     - type: org.junit.jupiter.api.Assertions
+    - type: org.testng.AssertJUnit
 availableFixes:
 - doStaticImports: true
   name: Change to assertThat(actual).isEqualTo(expected)

--- a/recipes/Java/AssertJ/From JUnit/JUnit_assertEquals_message.yaml
+++ b/recipes/Java/AssertJ/From JUnit/JUnit_assertEquals_message.yaml
@@ -6,7 +6,7 @@ metadata:
   level: warning
   language: java
   enabled: true
-  tags: AssertJ
+  tags: AssertJ; TestNG
 search:
   methodcall:
     argCount: 3
@@ -28,6 +28,10 @@ search:
         3:
           type: String
       type: org.junit.jupiter.api.Assertions
+    - args:
+        1:
+          type: String
+      type: org.testng.AssertJUnit
 availableFixes:
 - doStaticImports: true
   name: Change to assertThat(actual).as(message).isEqualTo(expected)

--- a/recipes/Java/AssertJ/From JUnit/JUnit_assertFalse_message.yaml
+++ b/recipes/Java/AssertJ/From JUnit/JUnit_assertFalse_message.yaml
@@ -6,7 +6,7 @@ metadata:
   level: warning
   language: java
   enabled: true
-  tags: AssertJ
+  tags: AssertJ; TestNG
 search:
   methodcall:
     argCount: 2
@@ -23,6 +23,7 @@ search:
       - type: org.junit.Assert
       - type: junit.framework.TestCase
       - type: junit.framework.Assert
+      - type: org.testng.AssertJUnit
     - args:
         1:
           anyOf:

--- a/recipes/Java/AssertJ/From JUnit/JUnit_assertNotNull.yaml
+++ b/recipes/Java/AssertJ/From JUnit/JUnit_assertNotNull.yaml
@@ -6,7 +6,7 @@ metadata:
   level: warning
   language: java
   enabled: true
-  tags: AssertJ
+  tags: AssertJ; TestNG
 search:
   methodcall:
     argCount: 1
@@ -16,6 +16,7 @@ search:
     - type: junit.framework.TestCase
     - type: junit.framework.Assert
     - type: org.junit.jupiter.api.Assertions
+    - type: org.testng.AssertJUnit
 availableFixes:
 - doStaticImports: true
   name: Change to assertThat(actual).isNotNull()

--- a/recipes/Java/AssertJ/From JUnit/JUnit_assertNotNull_message.yaml
+++ b/recipes/Java/AssertJ/From JUnit/JUnit_assertNotNull_message.yaml
@@ -6,7 +6,7 @@ metadata:
   level: warning
   language: java
   enabled: true
-  tags: AssertJ
+  tags: AssertJ; TestNG
 search:
   methodcall:
     argCount: 2
@@ -19,6 +19,7 @@ search:
       - type: org.junit.Assert
       - type: junit.framework.TestCase
       - type: junit.framework.Assert
+      - type: org.testng.AssertJUnit
     - args:
         2:
           type: String

--- a/recipes/Java/AssertJ/From JUnit/JUnit_assertNotSame.yaml
+++ b/recipes/Java/AssertJ/From JUnit/JUnit_assertNotSame.yaml
@@ -6,7 +6,7 @@ metadata:
   level: warning
   language: java
   enabled: true
-  tags: AssertJ
+  tags: AssertJ; TestNG
 search:
   methodcall:
     argCount: 2
@@ -16,6 +16,7 @@ search:
     - type: junit.framework.TestCase
     - type: junit.framework.Assert
     - type: org.junit.jupiter.api.Assertions
+    - type: org.testng.AssertJUnit
 availableFixes:
 - doStaticImports: true
   name: Change to assertThat(actual).isNotSameAs(expected)

--- a/recipes/Java/AssertJ/From JUnit/JUnit_assertNotSame_message.yaml
+++ b/recipes/Java/AssertJ/From JUnit/JUnit_assertNotSame_message.yaml
@@ -6,7 +6,7 @@ metadata:
   level: warning
   language: java
   enabled: true
-  tags: AssertJ
+  tags: AssertJ; TestNG
 search:
   methodcall:
     argCount: 3
@@ -19,6 +19,7 @@ search:
       - type: org.junit.Assert
       - type: junit.framework.TestCase
       - type: junit.framework.Assert
+      - type: org.testng.AssertJUnit
     - args:
         3:
           type: String

--- a/recipes/Java/AssertJ/From JUnit/JUnit_assertNull.yaml
+++ b/recipes/Java/AssertJ/From JUnit/JUnit_assertNull.yaml
@@ -6,7 +6,7 @@ metadata:
   level: warning
   language: java
   enabled: true
-  tags: AssertJ
+  tags: AssertJ; TestNG
 search:
   methodcall:
     argCount: 1
@@ -16,6 +16,7 @@ search:
     - type: junit.framework.TestCase
     - type: junit.framework.Assert
     - type: org.junit.jupiter.api.Assertions
+    - type: org.testng.AssertJUnit
 availableFixes:
 - doStaticImports: true
   name: Change to assertThat(actual).isNull()

--- a/recipes/Java/AssertJ/From JUnit/JUnit_assertNull_message.yaml
+++ b/recipes/Java/AssertJ/From JUnit/JUnit_assertNull_message.yaml
@@ -6,7 +6,7 @@ metadata:
   level: warning
   language: java
   enabled: true
-  tags: AssertJ
+  tags: AssertJ; TestNG
 search:
   methodcall:
     argCount: 2
@@ -19,6 +19,7 @@ search:
       - type: org.junit.Assert
       - type: junit.framework.TestCase
       - type: junit.framework.Assert
+      - type: org.testng.AssertJUnit
     - args:
         2:
           type: String

--- a/recipes/Java/AssertJ/From JUnit/JUnit_assertSame.yaml
+++ b/recipes/Java/AssertJ/From JUnit/JUnit_assertSame.yaml
@@ -6,7 +6,7 @@ metadata:
   level: warning
   language: java
   enabled: true
-  tags: AssertJ
+  tags: AssertJ; TestNG
 search:
   methodcall:
     argCount: 2
@@ -16,6 +16,7 @@ search:
     - type: junit.framework.TestCase
     - type: junit.framework.Assert
     - type: org.junit.jupiter.api.Assertions
+    - type: org.testng.AssertJUnit
 availableFixes:
 - doStaticImports: true
   name: Change to assertThat(actual).isSameAs(expected)

--- a/recipes/Java/AssertJ/From JUnit/JUnit_assertSame_message.yaml
+++ b/recipes/Java/AssertJ/From JUnit/JUnit_assertSame_message.yaml
@@ -6,7 +6,7 @@ metadata:
   level: warning
   language: java
   enabled: true
-  tags: AssertJ
+  tags: AssertJ; TestNG
 search:
   methodcall:
     argCount: 3
@@ -19,6 +19,7 @@ search:
       - type: org.junit.Assert
       - type: junit.framework.TestCase
       - type: junit.framework.Assert
+      - type: org.testng.AssertJUnit
     - args:
         3:
           type: String

--- a/recipes/Java/AssertJ/From JUnit/JUnit_assertTrue_message.yaml
+++ b/recipes/Java/AssertJ/From JUnit/JUnit_assertTrue_message.yaml
@@ -6,7 +6,7 @@ metadata:
   level: warning
   language: java
   enabled: true
-  tags: AssertJ
+  tags: AssertJ; TestNG
 search:
   methodcall:
     argCount: 2
@@ -23,6 +23,7 @@ search:
       - type: org.junit.Assert
       - type: junit.framework.TestCase
       - type: junit.framework.Assert
+      - type: org.testng.AssertJUnit
     - args:
         1:
           anyOf:

--- a/recipes/Java/AssertJ/From TestNG/TestNG_assertEquals.yaml
+++ b/recipes/Java/AssertJ/From TestNG/TestNG_assertEquals.yaml
@@ -1,0 +1,40 @@
+id: scw:assertj:testng-assert-equals
+version: 10
+metadata:
+  name: Use AssertJ's isEqualTo()
+  shortDescription: Can be replaced with AssertJ style assertions
+  level: warning
+  language: java
+  enabled: true
+  tags: AssertJ; TestNG
+search:
+  methodcall:
+    name: assertEquals
+    anyOf:
+    - argCount: 2
+    - args:
+        3:
+          type: String
+      argCount: 3
+    type: org.testng.Assert
+availableFixes:
+- doStaticImports: true
+  name: Change to assertThat(actual).isEqualTo(expected)
+  availableIf:
+    markedElement:
+      is:
+        methodcall:
+          argCount: 2
+  actions:
+  - rewrite:
+      to: org.assertj.core.api.Assertions.assertThat({{{ arguments.0 }}}).isEqualTo({{{ arguments.1 }}})
+- doStaticImports: true
+  name: Change to assertThat(actual).as(message).isEqualTo(expected)
+  availableIf:
+    markedElement:
+      is:
+        methodcall:
+          argCount: 3
+  actions:
+  - rewrite:
+      to: org.assertj.core.api.Assertions.assertThat({{{ arguments.0 }}}).as({{{ arguments.2 }}}).isEqualTo({{{ arguments.1 }}})

--- a/recipes/Java/AssertJ/From TestNG/TestNG_assertFalse.yaml
+++ b/recipes/Java/AssertJ/From TestNG/TestNG_assertFalse.yaml
@@ -1,4 +1,4 @@
-id: scw:assertj:junit-assert-false
+id: scw:assertj:testng-assert-false
 version: 10
 metadata:
   name: Use AssertJ's isFalse()
@@ -14,17 +14,29 @@ search:
         anyOf:
         - type: java.lang.Boolean
         - type: boolean
-    argCount: 1
+    argCount:
+      lessThanOrEquals: 2
+      greaterThanOrEquals: 1
     name: assertFalse
-    anyOf:
-    - type: org.junit.Assert
-    - type: junit.framework.TestCase
-    - type: junit.framework.Assert
-    - type: org.junit.jupiter.api.Assertions
-    - type: org.testng.AssertJUnit
+    type: org.testng.Assert
 availableFixes:
 - doStaticImports: true
   name: Change to assertThat(actual).isFalse()
+  availableIf:
+    markedElement:
+      is:
+        methodcall:
+          argCount: 1
   actions:
   - rewrite:
       to: org.assertj.core.api.Assertions.assertThat({{{ arguments.0 }}}).isFalse()
+- doStaticImports: true
+  name: Change to assertThat(actual).as(message).isFalse()
+  availableIf:
+    markedElement:
+      is:
+        methodcall:
+          argCount: 2
+  actions:
+  - rewrite:
+      to: org.assertj.core.api.Assertions.assertThat({{{ arguments.0 }}}).as({{{ arguments.1 }}}).isFalse()

--- a/recipes/Java/AssertJ/From TestNG/TestNG_assertNotEquals.yaml
+++ b/recipes/Java/AssertJ/From TestNG/TestNG_assertNotEquals.yaml
@@ -1,0 +1,40 @@
+id: scw:assertj:testng-assert-not-equals
+version: 10
+metadata:
+  name: Use AssertJ's isNotEqualTo()
+  shortDescription: Can be replaced with AssertJ style assertions
+  level: warning
+  language: java
+  enabled: true
+  tags: AssertJ; TestNG
+search:
+  methodcall:
+    name: assertNotEquals
+    anyOf:
+    - argCount: 2
+    - args:
+        3:
+          type: String
+      argCount: 3
+    type: org.testng.Assert
+availableFixes:
+- doStaticImports: true
+  name: Change to assertThat(actual).isNotEqualTo(expected)
+  availableIf:
+    markedElement:
+      is:
+        methodcall:
+          argCount: 2
+  actions:
+  - rewrite:
+      to: org.assertj.core.api.Assertions.assertThat({{{ arguments.0 }}}).isNotEqualTo({{{ arguments.1 }}})
+- doStaticImports: true
+  name: Change to assertThat(actual).as(message).isNotEqualTo(expected)
+  availableIf:
+    markedElement:
+      is:
+        methodcall:
+          argCount: 3
+  actions:
+  - rewrite:
+      to: org.assertj.core.api.Assertions.assertThat({{{ arguments.0 }}}).as({{{ arguments.2 }}}).isNotEqualTo({{{ arguments.1 }}})

--- a/recipes/Java/AssertJ/From TestNG/TestNG_assertNotNull.yaml
+++ b/recipes/Java/AssertJ/From TestNG/TestNG_assertNotNull.yaml
@@ -1,0 +1,37 @@
+id: scw:assertj:testng-assert-not-null
+version: 10
+metadata:
+  name: Use AssertJ's isNotNull()
+  shortDescription: Can be replaced with AssertJ style assertions
+  level: warning
+  language: java
+  enabled: true
+  tags: AssertJ; TestNG
+search:
+  methodcall:
+    argCount:
+      lessThanOrEquals: 2
+      greaterThanOrEquals: 1
+    name: assertNotNull
+    type: org.testng.Assert
+availableFixes:
+- doStaticImports: true
+  name: Change to assertThat(actual).isNotNull()
+  availableIf:
+    markedElement:
+      is:
+        methodcall:
+          argCount: 1
+  actions:
+  - rewrite:
+      to: org.assertj.core.api.Assertions.assertThat({{{ arguments.0 }}}).isNotNull()
+- doStaticImports: true
+  name: Change to assertThat(actual).as(message).isNotNull()
+  availableIf:
+    markedElement:
+      is:
+        methodcall:
+          argCount: 2
+  actions:
+  - rewrite:
+      to: org.assertj.core.api.Assertions.assertThat({{{ arguments.0 }}}).as({{{ arguments.1 }}}).isNotNull()

--- a/recipes/Java/AssertJ/From TestNG/TestNG_assertNotSame.yaml
+++ b/recipes/Java/AssertJ/From TestNG/TestNG_assertNotSame.yaml
@@ -1,0 +1,37 @@
+id: scw:assertj:testng-assert-not-same
+version: 10
+metadata:
+  name: Use AssertJ's isNotSameAs()
+  shortDescription: Can be replaced with AssertJ style assertions
+  level: warning
+  language: java
+  enabled: true
+  tags: AssertJ; TestNG
+search:
+  methodcall:
+    argCount:
+      lessThanOrEquals: 3
+      greaterThanOrEquals: 2
+    name: assertNotSame
+    type: org.testng.Assert
+availableFixes:
+- doStaticImports: true
+  name: Change to assertThat(actual).isNotSameAs(expected)
+  availableIf:
+    markedElement:
+      is:
+        methodcall:
+          argCount: 2
+  actions:
+  - rewrite:
+      to: org.assertj.core.api.Assertions.assertThat({{{ arguments.0 }}}).isNotSameAs({{{ arguments.1 }}})
+- doStaticImports: true
+  name: Change to assertThat(actual).as(message).isNotSameAs(expected)
+  availableIf:
+    markedElement:
+      is:
+        methodcall:
+          argCount: 3
+  actions:
+  - rewrite:
+      to: org.assertj.core.api.Assertions.assertThat({{{ arguments.0 }}}).as({{{ arguments.2 }}}).isNotSameAs({{{ arguments.1 }}})

--- a/recipes/Java/AssertJ/From TestNG/TestNG_assertNull.yaml
+++ b/recipes/Java/AssertJ/From TestNG/TestNG_assertNull.yaml
@@ -1,0 +1,37 @@
+id: scw:assertj:testng-assert-null
+version: 10
+metadata:
+  name: Use AssertJ's isNull()
+  shortDescription: Can be replaced with AssertJ style assertions
+  level: warning
+  language: java
+  enabled: true
+  tags: AssertJ; TestNG
+search:
+  methodcall:
+    argCount:
+      lessThanOrEquals: 2
+      greaterThanOrEquals: 1
+    name: assertNull
+    type: org.testng.Assert
+availableFixes:
+- doStaticImports: true
+  name: Change to assertThat(actual).isNull()
+  availableIf:
+    markedElement:
+      is:
+        methodcall:
+          argCount: 1
+  actions:
+  - rewrite:
+      to: org.assertj.core.api.Assertions.assertThat({{{ arguments.0 }}}).isNull()
+- doStaticImports: true
+  name: Change to assertThat(actual).as(message).isNull()
+  availableIf:
+    markedElement:
+      is:
+        methodcall:
+          argCount: 2
+  actions:
+  - rewrite:
+      to: org.assertj.core.api.Assertions.assertThat({{{ arguments.0 }}}).as({{{ arguments.1 }}}).isNull()

--- a/recipes/Java/AssertJ/From TestNG/TestNG_assertSame.yaml
+++ b/recipes/Java/AssertJ/From TestNG/TestNG_assertSame.yaml
@@ -1,0 +1,37 @@
+id: scw:assertj:testng-assert-same
+version: 10
+metadata:
+  name: Use AssertJ's isSameAs()
+  shortDescription: Can be replaced with AssertJ style assertions
+  level: warning
+  language: java
+  enabled: true
+  tags: AssertJ; TestNG
+search:
+  methodcall:
+    argCount:
+      lessThanOrEquals: 3
+      greaterThanOrEquals: 2
+    name: assertSame
+    type: org.testng.Assert
+availableFixes:
+- doStaticImports: true
+  name: Change to assertThat(actual).isSameAs(expected)
+  availableIf:
+    markedElement:
+      is:
+        methodcall:
+          argCount: 2
+  actions:
+  - rewrite:
+      to: org.assertj.core.api.Assertions.assertThat({{{ arguments.0 }}}).isSameAs({{{ arguments.1 }}})
+- doStaticImports: true
+  name: Change to assertThat(actual).as(message).isSameAs(expected)
+  availableIf:
+    markedElement:
+      is:
+        methodcall:
+          argCount: 3
+  actions:
+  - rewrite:
+      to: org.assertj.core.api.Assertions.assertThat({{{ arguments.0 }}}).as({{{ arguments.2 }}}).isSameAs({{{ arguments.1 }}})

--- a/recipes/Java/AssertJ/From TestNG/TestNG_assertThrows.yaml
+++ b/recipes/Java/AssertJ/From TestNG/TestNG_assertThrows.yaml
@@ -1,0 +1,36 @@
+id: scw:assertj:testng-assert-throws
+version: 10
+metadata:
+  name: Use AssertJ ThrowingCallable assertions
+  shortDescription: Use AssertJ ThrowingCallable assertions
+  level: warning
+  language: java
+  enabled: true
+  tags: AssertJ; TestNG
+search:
+  methodcall:
+    args:
+      1:
+        type:
+          reference:
+            matches: java\.lang\.Class<.*>
+          checkInheritance: true
+    argCount: 2
+    name: assertThrows
+    type: org.testng.Assert
+availableFixes:
+- doStaticImports: true
+  name: 'Use AssertJ: assertThatCode(code).isInstanceOf(throwableClass)'
+  actions:
+  - rewrite:
+      to: org.assertj.core.api.Assertions.assertThatCode({{{ arguments.1 }}}).isInstanceOf({{{ arguments.0 }}})
+- doStaticImports: true
+  name: 'Use AssertJ: assertThatExceptionOfType(throwableClass).isThrownBy(code)'
+  actions:
+  - rewrite:
+      to: org.assertj.core.api.Assertions.assertThatExceptionOfType({{{ arguments.0 }}}).isThrownBy({{{ arguments.1 }}})
+- doStaticImports: true
+  name: 'Use AssertJ: assertThatThrownBy(code).isInstanceOf(throwableClass)'
+  actions:
+  - rewrite:
+      to: org.assertj.core.api.Assertions.assertThatThrownBy({{{ arguments.1 }}}).isInstanceOf({{{ arguments.0 }}})

--- a/recipes/Java/AssertJ/From TestNG/TestNG_assertTrue.yaml
+++ b/recipes/Java/AssertJ/From TestNG/TestNG_assertTrue.yaml
@@ -1,4 +1,4 @@
-id: scw:assertj:junit-assert-true
+id: scw:assertj:testng-assert-true
 version: 10
 metadata:
   name: Use AssertJ's isTrue()
@@ -14,17 +14,29 @@ search:
         anyOf:
         - type: java.lang.Boolean
         - type: boolean
-    argCount: 1
+    argCount:
+      lessThanOrEquals: 2
+      greaterThanOrEquals: 1
     name: assertTrue
-    anyOf:
-    - type: org.junit.Assert
-    - type: junit.framework.TestCase
-    - type: junit.framework.Assert
-    - type: org.junit.jupiter.api.Assertions
-    - type: org.testng.AssertJUnit
+    type: org.testng.Assert
 availableFixes:
 - doStaticImports: true
   name: Change to assertThat(actual).isTrue()
+  availableIf:
+    markedElement:
+      is:
+        methodcall:
+          argCount: 1
   actions:
   - rewrite:
       to: org.assertj.core.api.Assertions.assertThat({{{ arguments.0 }}}).isTrue()
+- doStaticImports: true
+  name: Change to assertThat(actual).as(message).isTrue()
+  availableIf:
+    markedElement:
+      is:
+        methodcall:
+          argCount: 2
+  actions:
+  - rewrite:
+      to: org.assertj.core.api.Assertions.assertThat({{{ arguments.0 }}}).as({{{ arguments.1 }}}).isTrue()

--- a/recipes/Java/AssertJ/From TestNG/TestNG_fail.yaml
+++ b/recipes/Java/AssertJ/From TestNG/TestNG_fail.yaml
@@ -1,4 +1,4 @@
-id: scw:assertj:junit-fail
+id: scw:assertj:testng-fail
 version: 10
 metadata:
   name: Use AssertJ's fail()
@@ -19,29 +19,26 @@ search:
     argCount:
       lessThanOrEquals: 2
     name: fail
-    anyOf:
-    - type: org.junit.Assert
-    - type: junit.framework.TestCase
-    - type: junit.framework.Assert
-    - type: org.junit.jupiter.api.Assertions
-    - type: org.testng.AssertJUnit
+    type: org.testng.Assert
 availableFixes:
 - doStaticImports: true
   name: Use AssertJ's fail()
+  availableIf:
+    markedElement:
+      is:
+        methodcall:
+          argCount: 0
   actions:
   - rewrite:
-      applyIf:
-        markedElement:
-          is:
-            methodcall:
-              argCount: 0
       to: org.assertj.core.api.Assertions.fail("")
       target: self
+- doStaticImports: true
+  name: Use AssertJ's fail(message)
+  availableIf:
+    markedElement:
+      is:
+        methodcall:
+          argCount: 1
+  actions:
   - rewrite:
-      applyIf:
-        markedElement:
-          is:
-            methodcall:
-              argCount: 1
       to: org.assertj.core.api.Assertions.fail({{{ arguments.0 }}})
-      target: self


### PR DESCRIPTION
N.b.

TestNG has (at least) two classes of Assertions:
- `org.testng.Assert` (e.g. `org.testng.Assert.assertEquals(actual, expected, message)`)
- `org.testng.AssertJUnit` (e.g. `org.testng.AssertJUnit.assertEquals(message, expected, actual)`)

The latter provides an API that is comparable with `org.junit.Assert`, so it was super easy to add it to the existing `From JUnit` recipes. 
The former, however, orders the arguments differently from our existing recipes so I opted to create a new directory to handle those Assertions, instead of complicating the `From JUnit` recipes further still.

I found this approach to make sense, but there are other valid ways of solving this. Let me know if you want me to revisit this approach.