### PR TITLE
SEN-2585 Add recipes for migrating Hamcrest assertions to AssertJ

### DIFF
--- a/example_code/assertj/pom.xml
+++ b/example_code/assertj/pom.xml
@@ -52,6 +52,12 @@
             <version>7.4.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <version>2.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/example_code/assertj/src/test/java/hamcrest/HamcrestEmptyCollectionAssertions.java
+++ b/example_code/assertj/src/test/java/hamcrest/HamcrestEmptyCollectionAssertions.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -149,6 +150,47 @@ public class HamcrestEmptyCollectionAssertions {
             assertThat("reason", emptyArray, org.hamcrest.CoreMatchers.is(org.hamcrest.Matchers.emptyArray()));
             assertThat("reason", emptyArray, org.hamcrest.core.Is.is(org.hamcrest.Matchers.emptyArray()));
             assertThat("reason", emptyArray, org.hamcrest.Matchers.is(org.hamcrest.Matchers.emptyArray()));
+        }
+    }
+
+    @Nested
+    class EmptyMap {
+        Map<String, Object> emptyMap = Map.of();
+
+        @Test
+        void test_a_map_with_size() {
+            assertThat(emptyMap, org.hamcrest.Matchers.anEmptyMap());
+            assertThat(emptyMap, org.hamcrest.collection.IsMapWithSize.anEmptyMap());
+        }
+
+        @Test
+        void test_a_map_with_size_with_reason() {
+            assertThat("reason", emptyMap, org.hamcrest.Matchers.anEmptyMap());
+            assertThat("reason", emptyMap, org.hamcrest.collection.IsMapWithSize.anEmptyMap());
+        }
+
+        @Test
+        void test_is_a_map_with_size() {
+            assertThat(emptyMap, org.hamcrest.CoreMatchers.is(org.hamcrest.Matchers.anEmptyMap()));
+            assertThat(emptyMap, org.hamcrest.CoreMatchers.is(org.hamcrest.collection.IsMapWithSize.anEmptyMap()));
+
+            assertThat(emptyMap, org.hamcrest.core.Is.is(org.hamcrest.Matchers.anEmptyMap()));
+            assertThat(emptyMap, org.hamcrest.core.Is.is(org.hamcrest.collection.IsMapWithSize.anEmptyMap()));
+
+            assertThat(emptyMap, org.hamcrest.Matchers.is(org.hamcrest.Matchers.anEmptyMap()));
+            assertThat(emptyMap, org.hamcrest.Matchers.is(org.hamcrest.collection.IsMapWithSize.anEmptyMap()));
+        }
+
+        @Test
+        void test_is_a_map_with_size_with_reason() {
+            assertThat("reason", emptyMap, org.hamcrest.CoreMatchers.is(org.hamcrest.Matchers.anEmptyMap()));
+            assertThat("reason", emptyMap, org.hamcrest.CoreMatchers.is(org.hamcrest.collection.IsMapWithSize.anEmptyMap()));
+
+            assertThat("reason", emptyMap, org.hamcrest.core.Is.is(org.hamcrest.Matchers.anEmptyMap()));
+            assertThat("reason", emptyMap, org.hamcrest.core.Is.is(org.hamcrest.collection.IsMapWithSize.anEmptyMap()));
+
+            assertThat("reason", emptyMap, org.hamcrest.Matchers.is(org.hamcrest.Matchers.anEmptyMap()));
+            assertThat("reason", emptyMap, org.hamcrest.Matchers.is(org.hamcrest.collection.IsMapWithSize.anEmptyMap()));
         }
     }
 }

--- a/example_code/assertj/src/test/java/hamcrest/HamcrestEmptyCollectionAssertions.java
+++ b/example_code/assertj/src/test/java/hamcrest/HamcrestEmptyCollectionAssertions.java
@@ -1,0 +1,154 @@
+package hamcrest;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class HamcrestEmptyCollectionAssertions {
+    @Nested
+    class EmptyCollection {
+        private final Collection<String> emptyCollection = List.of();
+
+        @Test
+        void test_empty() {
+            assertThat(emptyCollection, org.hamcrest.Matchers.empty());
+            assertThat(emptyCollection, org.hamcrest.Matchers.emptyCollectionOf(String.class));
+            assertThat(emptyCollection, org.hamcrest.collection.IsEmptyCollection.empty());
+            assertThat(emptyCollection, org.hamcrest.collection.IsEmptyCollection.emptyCollectionOf(String.class));
+        }
+
+        @Test
+        void test_empty_with_reason() {
+            assertThat("reason", emptyCollection, org.hamcrest.Matchers.empty());
+            assertThat("reason", emptyCollection, org.hamcrest.Matchers.emptyCollectionOf(String.class));
+            assertThat("reason", emptyCollection, org.hamcrest.collection.IsEmptyCollection.empty());
+            assertThat("reason", emptyCollection, org.hamcrest.collection.IsEmptyCollection.emptyCollectionOf(String.class));
+        }
+
+        @Test
+        void test_is_empty() {
+            assertThat(emptyCollection, org.hamcrest.CoreMatchers.is(org.hamcrest.Matchers.empty()));
+            assertThat(emptyCollection, org.hamcrest.CoreMatchers.is(org.hamcrest.Matchers.emptyCollectionOf(String.class)));
+            assertThat(emptyCollection, org.hamcrest.CoreMatchers.is(org.hamcrest.collection.IsEmptyCollection.empty()));
+            assertThat(emptyCollection, org.hamcrest.CoreMatchers.is(org.hamcrest.collection.IsEmptyCollection.emptyCollectionOf(String.class)));
+
+            assertThat(emptyCollection, org.hamcrest.core.Is.is(org.hamcrest.Matchers.empty()));
+            assertThat(emptyCollection, org.hamcrest.core.Is.is(org.hamcrest.Matchers.emptyCollectionOf(String.class)));
+            assertThat(emptyCollection, org.hamcrest.core.Is.is(org.hamcrest.collection.IsEmptyCollection.empty()));
+            assertThat(emptyCollection, org.hamcrest.core.Is.is(org.hamcrest.collection.IsEmptyCollection.emptyCollectionOf(String.class)));
+
+            assertThat(emptyCollection, org.hamcrest.Matchers.is(org.hamcrest.Matchers.empty()));
+            assertThat(emptyCollection, org.hamcrest.Matchers.is(org.hamcrest.Matchers.emptyCollectionOf(String.class)));
+            assertThat(emptyCollection, org.hamcrest.Matchers.is(org.hamcrest.collection.IsEmptyCollection.empty()));
+            assertThat(emptyCollection, org.hamcrest.Matchers.is(org.hamcrest.collection.IsEmptyCollection.emptyCollectionOf(String.class)));
+        }
+
+        @Test
+        void test_is_empty_with_reason() {
+            assertThat("reason", emptyCollection, org.hamcrest.CoreMatchers.is(org.hamcrest.Matchers.empty()));
+            assertThat("reason", emptyCollection, org.hamcrest.CoreMatchers.is(org.hamcrest.Matchers.emptyCollectionOf(String.class)));
+            assertThat("reason", emptyCollection, org.hamcrest.CoreMatchers.is(org.hamcrest.collection.IsEmptyCollection.empty()));
+            assertThat("reason", emptyCollection, org.hamcrest.CoreMatchers.is(org.hamcrest.collection.IsEmptyCollection.emptyCollectionOf(String.class)));
+
+            assertThat("reason", emptyCollection, org.hamcrest.core.Is.is(org.hamcrest.Matchers.empty()));
+            assertThat("reason", emptyCollection, org.hamcrest.core.Is.is(org.hamcrest.Matchers.emptyCollectionOf(String.class)));
+            assertThat("reason", emptyCollection, org.hamcrest.core.Is.is(org.hamcrest.collection.IsEmptyCollection.empty()));
+            assertThat("reason", emptyCollection, org.hamcrest.core.Is.is(org.hamcrest.collection.IsEmptyCollection.emptyCollectionOf(String.class)));
+
+            assertThat("reason", emptyCollection, org.hamcrest.Matchers.is(org.hamcrest.Matchers.empty()));
+            assertThat("reason", emptyCollection, org.hamcrest.Matchers.is(org.hamcrest.Matchers.emptyCollectionOf(String.class)));
+            assertThat("reason", emptyCollection, org.hamcrest.Matchers.is(org.hamcrest.collection.IsEmptyCollection.empty()));
+            assertThat("reason", emptyCollection, org.hamcrest.Matchers.is(org.hamcrest.collection.IsEmptyCollection.emptyCollectionOf(String.class)));
+        }
+    }
+
+    @Nested
+    class EmptyIterable {
+        private final Iterable<String> emptyIterable = List.of();
+
+        @Test
+        void test_empty() {
+            assertThat(emptyIterable, org.hamcrest.Matchers.emptyIterable());
+            assertThat(emptyIterable, org.hamcrest.Matchers.emptyIterableOf(String.class));
+            assertThat(emptyIterable, org.hamcrest.collection.IsEmptyIterable.emptyIterable());
+            assertThat(emptyIterable, org.hamcrest.collection.IsEmptyIterable.emptyIterableOf(String.class));
+        }
+
+        @Test
+        void test_empty_with_reason() {
+            assertThat("reason", emptyIterable, org.hamcrest.Matchers.emptyIterable());
+            assertThat("reason", emptyIterable, org.hamcrest.Matchers.emptyIterableOf(String.class));
+            assertThat("reason", emptyIterable, org.hamcrest.collection.IsEmptyIterable.emptyIterable());
+            assertThat("reason", emptyIterable, org.hamcrest.collection.IsEmptyIterable.emptyIterableOf(String.class));
+        }
+
+        @Test
+        void test_is_empty() {
+            assertThat(emptyIterable, org.hamcrest.CoreMatchers.is(org.hamcrest.Matchers.emptyIterable()));
+            assertThat(emptyIterable, org.hamcrest.CoreMatchers.is(org.hamcrest.Matchers.emptyIterableOf(String.class)));
+            assertThat(emptyIterable, org.hamcrest.CoreMatchers.is(org.hamcrest.collection.IsEmptyIterable.emptyIterable()));
+            assertThat(emptyIterable, org.hamcrest.CoreMatchers.is(org.hamcrest.collection.IsEmptyIterable.emptyIterableOf(String.class)));
+
+            assertThat(emptyIterable, org.hamcrest.core.Is.is(org.hamcrest.Matchers.emptyIterable()));
+            assertThat(emptyIterable, org.hamcrest.core.Is.is(org.hamcrest.Matchers.emptyIterableOf(String.class)));
+            assertThat(emptyIterable, org.hamcrest.core.Is.is(org.hamcrest.collection.IsEmptyIterable.emptyIterable()));
+            assertThat(emptyIterable, org.hamcrest.core.Is.is(org.hamcrest.collection.IsEmptyIterable.emptyIterableOf(String.class)));
+
+            assertThat(emptyIterable, org.hamcrest.Matchers.is(org.hamcrest.Matchers.emptyIterable()));
+            assertThat(emptyIterable, org.hamcrest.Matchers.is(org.hamcrest.Matchers.emptyIterableOf(String.class)));
+            assertThat(emptyIterable, org.hamcrest.Matchers.is(org.hamcrest.collection.IsEmptyIterable.emptyIterable()));
+            assertThat(emptyIterable, org.hamcrest.Matchers.is(org.hamcrest.collection.IsEmptyIterable.emptyIterableOf(String.class)));
+        }
+
+        @Test
+        void test_is_empty_with_reason() {
+            assertThat("reason", emptyIterable, org.hamcrest.CoreMatchers.is(org.hamcrest.Matchers.emptyIterable()));
+            assertThat("reason", emptyIterable, org.hamcrest.CoreMatchers.is(org.hamcrest.Matchers.emptyIterableOf(String.class)));
+            assertThat("reason", emptyIterable, org.hamcrest.CoreMatchers.is(org.hamcrest.collection.IsEmptyIterable.emptyIterable()));
+            assertThat("reason", emptyIterable, org.hamcrest.CoreMatchers.is(org.hamcrest.collection.IsEmptyIterable.emptyIterableOf(String.class)));
+
+            assertThat("reason", emptyIterable, org.hamcrest.core.Is.is(org.hamcrest.Matchers.emptyIterable()));
+            assertThat("reason", emptyIterable, org.hamcrest.core.Is.is(org.hamcrest.Matchers.emptyIterableOf(String.class)));
+            assertThat("reason", emptyIterable, org.hamcrest.core.Is.is(org.hamcrest.collection.IsEmptyIterable.emptyIterable()));
+            assertThat("reason", emptyIterable, org.hamcrest.core.Is.is(org.hamcrest.collection.IsEmptyIterable.emptyIterableOf(String.class)));
+
+            assertThat("reason", emptyIterable, org.hamcrest.Matchers.is(org.hamcrest.Matchers.emptyIterable()));
+            assertThat("reason", emptyIterable, org.hamcrest.Matchers.is(org.hamcrest.Matchers.emptyIterableOf(String.class)));
+            assertThat("reason", emptyIterable, org.hamcrest.Matchers.is(org.hamcrest.collection.IsEmptyIterable.emptyIterable()));
+            assertThat("reason", emptyIterable, org.hamcrest.Matchers.is(org.hamcrest.collection.IsEmptyIterable.emptyIterableOf(String.class)));
+        }
+    }
+
+    @Nested
+    class EmptyArray {
+        private final String[] emptyArray = new String[]{};
+
+        @Test
+        void test_empty() {
+            assertThat(emptyArray, org.hamcrest.Matchers.emptyArray());
+        }
+
+        @Test
+        void test_empty_with_reason() {
+            assertThat("reason", emptyArray, org.hamcrest.Matchers.emptyArray());
+        }
+
+        @Test
+        void test_is_empty() {
+            assertThat(emptyArray, org.hamcrest.CoreMatchers.is(org.hamcrest.Matchers.emptyArray()));
+            assertThat(emptyArray, org.hamcrest.core.Is.is(org.hamcrest.Matchers.emptyArray()));
+            assertThat(emptyArray, org.hamcrest.Matchers.is(org.hamcrest.Matchers.emptyArray()));
+        }
+
+        @Test
+        void test_is_empty_with_reason() {
+            assertThat("reason", emptyArray, org.hamcrest.CoreMatchers.is(org.hamcrest.Matchers.emptyArray()));
+            assertThat("reason", emptyArray, org.hamcrest.core.Is.is(org.hamcrest.Matchers.emptyArray()));
+            assertThat("reason", emptyArray, org.hamcrest.Matchers.is(org.hamcrest.Matchers.emptyArray()));
+        }
+    }
+}

--- a/example_code/assertj/src/test/java/hamcrest/HamcrestEmptyCollectionAssertions.java
+++ b/example_code/assertj/src/test/java/hamcrest/HamcrestEmptyCollectionAssertions.java
@@ -158,19 +158,19 @@ public class HamcrestEmptyCollectionAssertions {
         Map<String, Object> emptyMap = Map.of();
 
         @Test
-        void test_a_map_with_size() {
+        void test_an_empty_map() {
             assertThat(emptyMap, org.hamcrest.Matchers.anEmptyMap());
             assertThat(emptyMap, org.hamcrest.collection.IsMapWithSize.anEmptyMap());
         }
 
         @Test
-        void test_a_map_with_size_with_reason() {
+        void test_an_empty_map_with_reason() {
             assertThat("reason", emptyMap, org.hamcrest.Matchers.anEmptyMap());
             assertThat("reason", emptyMap, org.hamcrest.collection.IsMapWithSize.anEmptyMap());
         }
 
         @Test
-        void test_is_a_map_with_size() {
+        void test_is_an_empty_map() {
             assertThat(emptyMap, org.hamcrest.CoreMatchers.is(org.hamcrest.Matchers.anEmptyMap()));
             assertThat(emptyMap, org.hamcrest.CoreMatchers.is(org.hamcrest.collection.IsMapWithSize.anEmptyMap()));
 
@@ -182,7 +182,7 @@ public class HamcrestEmptyCollectionAssertions {
         }
 
         @Test
-        void test_is_a_map_with_size_with_reason() {
+        void test_is_an_empty_map_with_reason() {
             assertThat("reason", emptyMap, org.hamcrest.CoreMatchers.is(org.hamcrest.Matchers.anEmptyMap()));
             assertThat("reason", emptyMap, org.hamcrest.CoreMatchers.is(org.hamcrest.collection.IsMapWithSize.anEmptyMap()));
 

--- a/example_code/assertj/src/test/java/hamcrest/HamcrestEqualsAssertions.java
+++ b/example_code/assertj/src/test/java/hamcrest/HamcrestEqualsAssertions.java
@@ -1,0 +1,69 @@
+package hamcrest;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class HamcrestEqualsAssertions {
+
+    private final String actual = "hello" + " world";
+    private final String expected = "hello world";
+
+    @Test
+    void test_equalTo() {
+        assertThat(actual, org.hamcrest.CoreMatchers.equalTo(expected));
+        assertThat(actual, org.hamcrest.core.IsEqual.equalTo(expected));
+        assertThat(actual, org.hamcrest.Matchers.equalTo(expected));
+    }
+
+    @Test
+    void test_equalTo_with_reason() {
+        assertThat("reason", actual, org.hamcrest.CoreMatchers.equalTo(expected));
+        assertThat("reason", actual, org.hamcrest.core.IsEqual.equalTo(expected));
+        assertThat("reason", actual, org.hamcrest.Matchers.equalTo(expected));
+    }
+
+    @Test
+    void test_is() {
+        assertThat(actual, org.hamcrest.CoreMatchers.is(expected));
+        assertThat(actual, org.hamcrest.core.Is.is(expected));
+        assertThat(actual, org.hamcrest.Matchers.is(expected));
+    }
+
+    @Test
+    void test_is_with_reason() {
+        assertThat("reason", actual, org.hamcrest.CoreMatchers.is(expected));
+        assertThat("reason", actual, org.hamcrest.core.Is.is(expected));
+        assertThat("reason", actual, org.hamcrest.Matchers.is(expected));
+    }
+
+    @Test
+    void test_isEqualTo() {
+        assertThat(actual, org.hamcrest.CoreMatchers.is(org.hamcrest.CoreMatchers.equalTo(expected)));
+        assertThat(actual, org.hamcrest.CoreMatchers.is(org.hamcrest.core.IsEqual.equalTo(expected)));
+        assertThat(actual, org.hamcrest.CoreMatchers.is(org.hamcrest.Matchers.equalTo(expected)));
+
+        assertThat(actual, org.hamcrest.core.Is.is(org.hamcrest.CoreMatchers.equalTo(expected)));
+        assertThat(actual, org.hamcrest.core.Is.is(org.hamcrest.core.IsEqual.equalTo(expected)));
+        assertThat(actual, org.hamcrest.core.Is.is(org.hamcrest.Matchers.equalTo(expected)));
+
+        assertThat(actual, org.hamcrest.Matchers.is(org.hamcrest.CoreMatchers.equalTo(expected)));
+        assertThat(actual, org.hamcrest.Matchers.is(org.hamcrest.core.IsEqual.equalTo(expected)));
+        assertThat(actual, org.hamcrest.Matchers.is(org.hamcrest.Matchers.equalTo(expected)));
+    }
+
+    @Test
+    void test_isEqualTo_with_reason() {
+        assertThat("reason", actual, org.hamcrest.CoreMatchers.is(org.hamcrest.CoreMatchers.equalTo(expected)));
+        assertThat("reason", actual, org.hamcrest.CoreMatchers.is(org.hamcrest.core.IsEqual.equalTo(expected)));
+        assertThat("reason", actual, org.hamcrest.CoreMatchers.is(org.hamcrest.Matchers.equalTo(expected)));
+
+        assertThat("reason", actual, org.hamcrest.core.Is.is(org.hamcrest.CoreMatchers.equalTo(expected)));
+        assertThat("reason", actual, org.hamcrest.core.Is.is(org.hamcrest.core.IsEqual.equalTo(expected)));
+        assertThat("reason", actual, org.hamcrest.core.Is.is(org.hamcrest.Matchers.equalTo(expected)));
+
+        assertThat("reason", actual, org.hamcrest.Matchers.is(org.hamcrest.CoreMatchers.equalTo(expected)));
+        assertThat("reason", actual, org.hamcrest.Matchers.is(org.hamcrest.core.IsEqual.equalTo(expected)));
+        assertThat("reason", actual, org.hamcrest.Matchers.is(org.hamcrest.Matchers.equalTo(expected)));
+    }
+}

--- a/recipes/Java/AssertJ/From Hamcrest/Hamcrest_empty.yaml
+++ b/recipes/Java/AssertJ/From Hamcrest/Hamcrest_empty.yaml
@@ -35,6 +35,10 @@ search:
                   type: org.hamcrest.collection.IsEmptyIterable
                 - name: emptyArray
                   type: org.hamcrest.Matchers
+                - name: anEmptyMap
+                  type: org.hamcrest.Matchers
+                - name: anEmptyMap
+                  type: org.hamcrest.collection.IsMapWithSize
       argCount: 2
     - args:
         1:
@@ -62,6 +66,10 @@ search:
                   type: org.hamcrest.collection.IsEmptyIterable
                 - name: emptyArray
                   type: org.hamcrest.Matchers
+                - name: anEmptyMap
+                  type: org.hamcrest.Matchers
+                - name: anEmptyMap
+                  type: org.hamcrest.collection.IsMapWithSize
       argCount: 3
     type: org.hamcrest.MatcherAssert
 availableFixes:

--- a/recipes/Java/AssertJ/From Hamcrest/Hamcrest_empty.yaml
+++ b/recipes/Java/AssertJ/From Hamcrest/Hamcrest_empty.yaml
@@ -1,0 +1,87 @@
+id: scw:assertj:hamcrest-empty
+version: 10
+metadata:
+  name: Use AssertJ's isEmpty() instead of empty/emptyCollection/emptyIterable
+  shortDescription: Can be replaced with AssertJ style assertions
+  level: warning
+  language: java
+  enabled: true
+  tags: AssertJ; Hamcrest
+search:
+  methodcall:
+    name: assertThat
+    anyOf:
+    - args:
+        2:
+          value:
+            is:
+              methodcall:
+                anyOf:
+                - name: empty
+                  type: org.hamcrest.Matchers
+                - name: emptyCollectionOf
+                  type: org.hamcrest.Matchers
+                - name: empty
+                  type: org.hamcrest.collection.IsEmptyCollection
+                - name: emptyCollectionOf
+                  type: org.hamcrest.collection.IsEmptyCollection
+                - name: emptyIterable
+                  type: org.hamcrest.Matchers
+                - name: emptyIterableOf
+                  type: org.hamcrest.Matchers
+                - name: emptyIterable
+                  type: org.hamcrest.collection.IsEmptyIterable
+                - name: emptyIterableOf
+                  type: org.hamcrest.collection.IsEmptyIterable
+                - name: emptyArray
+                  type: org.hamcrest.Matchers
+      argCount: 2
+    - args:
+        1:
+          type: String
+        3:
+          value:
+            is:
+              methodcall:
+                anyOf:
+                - name: empty
+                  type: org.hamcrest.Matchers
+                - name: emptyCollectionOf
+                  type: org.hamcrest.Matchers
+                - name: empty
+                  type: org.hamcrest.collection.IsEmptyCollection
+                - name: emptyCollectionOf
+                  type: org.hamcrest.collection.IsEmptyCollection
+                - name: emptyIterable
+                  type: org.hamcrest.Matchers
+                - name: emptyIterableOf
+                  type: org.hamcrest.Matchers
+                - name: emptyIterable
+                  type: org.hamcrest.collection.IsEmptyIterable
+                - name: emptyIterableOf
+                  type: org.hamcrest.collection.IsEmptyIterable
+                - name: emptyArray
+                  type: org.hamcrest.Matchers
+      argCount: 3
+    type: org.hamcrest.MatcherAssert
+availableFixes:
+- doStaticImports: false
+  name: Change to assertThat(actual).isEqualTo(expected)
+  availableIf:
+    markedElement:
+      is:
+        methodcall:
+          argCount: 2
+  actions:
+  - rewrite:
+      to: org.assertj.core.api.Assertions.assertThat({{{ arguments.0 }}}).isEmpty()
+- doStaticImports: false
+  name: Change to assertThat(actual).as(reason).isEqualTo(expected)
+  availableIf:
+    markedElement:
+      is:
+        methodcall:
+          argCount: 3
+  actions:
+  - rewrite:
+      to: org.assertj.core.api.Assertions.assertThat({{{ arguments.1 }}}).as({{{ arguments.0 }}}).isEmpty()

--- a/recipes/Java/AssertJ/From Hamcrest/Hamcrest_empty.yaml
+++ b/recipes/Java/AssertJ/From Hamcrest/Hamcrest_empty.yaml
@@ -65,7 +65,7 @@ search:
       argCount: 3
     type: org.hamcrest.MatcherAssert
 availableFixes:
-- doStaticImports: false
+- doStaticImports: true
   name: Change to assertThat(actual).isEqualTo(expected)
   availableIf:
     markedElement:
@@ -75,7 +75,7 @@ availableFixes:
   actions:
   - rewrite:
       to: org.assertj.core.api.Assertions.assertThat({{{ arguments.0 }}}).isEmpty()
-- doStaticImports: false
+- doStaticImports: true
   name: Change to assertThat(actual).as(reason).isEqualTo(expected)
   availableIf:
     markedElement:

--- a/recipes/Java/AssertJ/From Hamcrest/Hamcrest_equalTo.yaml
+++ b/recipes/Java/AssertJ/From Hamcrest/Hamcrest_equalTo.yaml
@@ -61,7 +61,7 @@ search:
       argCount: 3
     type: org.hamcrest.MatcherAssert
 availableFixes:
-- doStaticImports: false
+- doStaticImports: true
   name: Change to assertThat(actual).isEqualTo(expected)
   availableIf:
     markedElement:
@@ -71,7 +71,7 @@ availableFixes:
   actions:
   - rewrite:
       to: org.assertj.core.api.Assertions.assertThat({{{ arguments.0 }}}).isEqualTo({{{ arguments.1.arguments.0 }}})
-- doStaticImports: false
+- doStaticImports: true
   name: Change to assertThat(actual).as(reason).isEqualTo(expected)
   availableIf:
     markedElement:

--- a/recipes/Java/AssertJ/From Hamcrest/Hamcrest_equalTo.yaml
+++ b/recipes/Java/AssertJ/From Hamcrest/Hamcrest_equalTo.yaml
@@ -1,0 +1,83 @@
+id: scw:assertj:hamcrest-equal-to
+version: 10
+metadata:
+  name: Use AssertJ's isEqualTo() instead of equalTo/is
+  shortDescription: Can be replaced with AssertJ style assertions
+  level: warning
+  language: java
+  enabled: true
+  tags: AssertJ; Hamcrest
+search:
+  methodcall:
+    name: assertThat
+    anyOf:
+    - args:
+        2:
+          value:
+            is:
+              methodcall:
+                anyOf:
+                - name: equalTo
+                  type:
+                    reference:
+                      matches: org\.hamcrest\.(CoreMatchers|Matchers|core\.IsEqual)
+                    checkInheritance: true
+                - args:
+                    1:
+                      value:
+                        not:
+                          is:
+                            methodcall: {}
+                  name: is
+                  type:
+                    reference:
+                      matches: org\.hamcrest\.(CoreMatchers|Matchers|core\.Is)
+                    checkInheritance: true
+      argCount: 2
+    - args:
+        1:
+          type: String
+        3:
+          value:
+            is:
+              methodcall:
+                anyOf:
+                - name: equalTo
+                  type:
+                    reference:
+                      matches: org\.hamcrest\.(CoreMatchers|Matchers|core\.IsEqual)
+                    checkInheritance: true
+                - args:
+                    1:
+                      value:
+                        not:
+                          is:
+                            methodcall: {}
+                  name: is
+                  type:
+                    reference:
+                      matches: org\.hamcrest\.(CoreMatchers|Matchers|core\.Is)
+                    checkInheritance: true
+      argCount: 3
+    type: org.hamcrest.MatcherAssert
+availableFixes:
+- doStaticImports: false
+  name: Change to assertThat(actual).isEqualTo(expected)
+  availableIf:
+    markedElement:
+      is:
+        methodcall:
+          argCount: 2
+  actions:
+  - rewrite:
+      to: org.assertj.core.api.Assertions.assertThat({{{ arguments.0 }}}).isEqualTo({{{ arguments.1.arguments.0 }}})
+- doStaticImports: false
+  name: Change to assertThat(actual).as(reason).isEqualTo(expected)
+  availableIf:
+    markedElement:
+      is:
+        methodcall:
+          argCount: 3
+  actions:
+  - rewrite:
+      to: org.assertj.core.api.Assertions.assertThat({{{ arguments.1 }}}).as({{{ arguments.0 }}}).isEqualTo({{{ arguments.2.arguments.0 }}})

--- a/recipes/Java/AssertJ/From Hamcrest/Hamcrest_isEmpty.yaml
+++ b/recipes/Java/AssertJ/From Hamcrest/Hamcrest_isEmpty.yaml
@@ -40,6 +40,10 @@ search:
                             type: org.hamcrest.collection.IsEmptyIterable
                           - name: emptyArray
                             type: org.hamcrest.Matchers
+                          - name: anEmptyMap
+                            type: org.hamcrest.Matchers
+                          - name: anEmptyMap
+                            type: org.hamcrest.collection.IsMapWithSize
                 name: is
                 type:
                   reference:
@@ -77,6 +81,10 @@ search:
                             type: org.hamcrest.collection.IsEmptyIterable
                           - name: emptyArray
                             type: org.hamcrest.Matchers
+                          - name: anEmptyMap
+                            type: org.hamcrest.Matchers
+                          - name: anEmptyMap
+                            type: org.hamcrest.collection.IsMapWithSize
                 name: is
                 type:
                   reference:

--- a/recipes/Java/AssertJ/From Hamcrest/Hamcrest_isEmpty.yaml
+++ b/recipes/Java/AssertJ/From Hamcrest/Hamcrest_isEmpty.yaml
@@ -85,7 +85,7 @@ search:
       argCount: 3
     type: org.hamcrest.MatcherAssert
 availableFixes:
-- doStaticImports: false
+- doStaticImports: true
   name: Change to assertThat(actual).isEqualTo(expected)
   availableIf:
     markedElement:
@@ -95,7 +95,7 @@ availableFixes:
   actions:
   - rewrite:
       to: org.assertj.core.api.Assertions.assertThat({{{ arguments.0 }}}).isEmpty()
-- doStaticImports: false
+- doStaticImports: true
   name: Change to assertThat(actual).as(reason).isEqualTo(expected)
   availableIf:
     markedElement:

--- a/recipes/Java/AssertJ/From Hamcrest/Hamcrest_isEmpty.yaml
+++ b/recipes/Java/AssertJ/From Hamcrest/Hamcrest_isEmpty.yaml
@@ -1,0 +1,107 @@
+id: scw:assertj:hamcrest-is-empty
+version: 10
+metadata:
+  name: Use AssertJ's isEmpty() instead of is(empty/emptyCollection/emptyIterable)
+  shortDescription: Can be replaced with AssertJ style assertions
+  level: warning
+  language: java
+  enabled: true
+  tags: AssertJ; Hamcrest
+search:
+  methodcall:
+    name: assertThat
+    anyOf:
+    - args:
+        2:
+          value:
+            is:
+              methodcall:
+                args:
+                  1:
+                    value:
+                      is:
+                        methodcall:
+                          anyOf:
+                          - name: empty
+                            type: org.hamcrest.Matchers
+                          - name: emptyCollectionOf
+                            type: org.hamcrest.Matchers
+                          - name: empty
+                            type: org.hamcrest.collection.IsEmptyCollection
+                          - name: emptyCollectionOf
+                            type: org.hamcrest.collection.IsEmptyCollection
+                          - name: emptyIterable
+                            type: org.hamcrest.Matchers
+                          - name: emptyIterableOf
+                            type: org.hamcrest.Matchers
+                          - name: emptyIterable
+                            type: org.hamcrest.collection.IsEmptyIterable
+                          - name: emptyIterableOf
+                            type: org.hamcrest.collection.IsEmptyIterable
+                          - name: emptyArray
+                            type: org.hamcrest.Matchers
+                name: is
+                type:
+                  reference:
+                    matches: org\.hamcrest\.(CoreMatchers|Matchers|core\.Is)
+                  checkInheritance: true
+      argCount: 2
+    - args:
+        1:
+          type: String
+        3:
+          value:
+            is:
+              methodcall:
+                args:
+                  1:
+                    value:
+                      is:
+                        methodcall:
+                          anyOf:
+                          - name: empty
+                            type: org.hamcrest.Matchers
+                          - name: emptyCollectionOf
+                            type: org.hamcrest.Matchers
+                          - name: empty
+                            type: org.hamcrest.collection.IsEmptyCollection
+                          - name: emptyCollectionOf
+                            type: org.hamcrest.collection.IsEmptyCollection
+                          - name: emptyIterable
+                            type: org.hamcrest.Matchers
+                          - name: emptyIterableOf
+                            type: org.hamcrest.Matchers
+                          - name: emptyIterable
+                            type: org.hamcrest.collection.IsEmptyIterable
+                          - name: emptyIterableOf
+                            type: org.hamcrest.collection.IsEmptyIterable
+                          - name: emptyArray
+                            type: org.hamcrest.Matchers
+                name: is
+                type:
+                  reference:
+                    matches: org\.hamcrest\.(CoreMatchers|Matchers|core\.Is)
+                  checkInheritance: true
+      argCount: 3
+    type: org.hamcrest.MatcherAssert
+availableFixes:
+- doStaticImports: false
+  name: Change to assertThat(actual).isEqualTo(expected)
+  availableIf:
+    markedElement:
+      is:
+        methodcall:
+          argCount: 2
+  actions:
+  - rewrite:
+      to: org.assertj.core.api.Assertions.assertThat({{{ arguments.0 }}}).isEmpty()
+- doStaticImports: false
+  name: Change to assertThat(actual).as(reason).isEqualTo(expected)
+  availableIf:
+    markedElement:
+      is:
+        methodcall:
+          argCount: 3
+  actions:
+  - rewrite:
+      to: org.assertj.core.api.Assertions.assertThat({{{ arguments.1 }}}).as({{{ arguments.0 }}}).isEmpty()

--- a/recipes/Java/AssertJ/From Hamcrest/Hamcrest_isEqualTo.yaml
+++ b/recipes/Java/AssertJ/From Hamcrest/Hamcrest_isEqualTo.yaml
@@ -57,7 +57,7 @@ search:
       argCount: 3
     type: org.hamcrest.MatcherAssert
 availableFixes:
-- doStaticImports: false
+- doStaticImports: true
   name: Change to assertThat(actual).isEqualTo(expected)
   availableIf:
     markedElement:
@@ -67,7 +67,7 @@ availableFixes:
   actions:
   - rewrite:
       to: org.assertj.core.api.Assertions.assertThat({{{ arguments.0 }}}).isEqualTo({{{ arguments.1.arguments.0.arguments }}})
-- doStaticImports: false
+- doStaticImports: true
   name: Change to assertThat(actual).as(reason).isEqualTo(expected)
   availableIf:
     markedElement:

--- a/recipes/Java/AssertJ/From Hamcrest/Hamcrest_isEqualTo.yaml
+++ b/recipes/Java/AssertJ/From Hamcrest/Hamcrest_isEqualTo.yaml
@@ -1,0 +1,79 @@
+id: scw:assertj:hamcrest-is-equal-to
+version: 10
+metadata:
+  name: Use AssertJ's isEqualTo() instead of is(equalTo())
+  shortDescription: Can be replaced with AssertJ style assertions
+  level: warning
+  language: java
+  enabled: true
+  tags: AssertJ; Hamcrest
+search:
+  methodcall:
+    name: assertThat
+    anyOf:
+    - args:
+        2:
+          value:
+            is:
+              methodcall:
+                args:
+                  1:
+                    value:
+                      is:
+                        methodcall:
+                          name: equalTo
+                          type:
+                            reference:
+                              matches: org\.hamcrest\.(CoreMatchers|Matchers|core\.IsEqual)
+                            checkInheritance: true
+                name: is
+                type:
+                  reference:
+                    matches: org\.hamcrest\.(CoreMatchers|Matchers|core\.Is)
+                  checkInheritance: true
+      argCount: 2
+    - args:
+        1:
+          type: String
+        3:
+          value:
+            is:
+              methodcall:
+                args:
+                  1:
+                    value:
+                      is:
+                        methodcall:
+                          name: equalTo
+                          type:
+                            reference:
+                              matches: org\.hamcrest\.(CoreMatchers|Matchers|core\.IsEqual)
+                            checkInheritance: true
+                name: is
+                type:
+                  reference:
+                    matches: org\.hamcrest\.(CoreMatchers|Matchers|core\.Is)
+                  checkInheritance: true
+      argCount: 3
+    type: org.hamcrest.MatcherAssert
+availableFixes:
+- doStaticImports: false
+  name: Change to assertThat(actual).isEqualTo(expected)
+  availableIf:
+    markedElement:
+      is:
+        methodcall:
+          argCount: 2
+  actions:
+  - rewrite:
+      to: org.assertj.core.api.Assertions.assertThat({{{ arguments.0 }}}).isEqualTo({{{ arguments.1.arguments.0.arguments }}})
+- doStaticImports: false
+  name: Change to assertThat(actual).as(reason).isEqualTo(expected)
+  availableIf:
+    markedElement:
+      is:
+        methodcall:
+          argCount: 3
+  actions:
+  - rewrite:
+      to: org.assertj.core.api.Assertions.assertThat({{{ arguments.1 }}}).as({{{ arguments.0 }}}).isEqualTo({{{ arguments.2.arguments.0.arguments.0 }}})


### PR DESCRIPTION
Keeping this fairly lean, only writing recipes for `isEqualTo` and `isEmpty`. Will write more recipes in separate PRs.

N.b. I chose to explicitly specify `doStaticImports` false, because presumably `org.hamcrest.MatcherAssert.assertThat` is already statically imported in those test classes, and it would clash with `org.assertj.core.api.Assertions.assertThat`