### PR TITLE
Update DateTime recipes to match for minusMillis/plusMillis

### DIFF
--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-isAfterNow.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-isAfterNow.yaml
@@ -8,7 +8,7 @@ metadata:
   enabled: true
   comment: |
     Joda-Time's DateTime class provided an isAfterNow method to conveniently check if the datetime is after the current Instant in time.
-    This method is not available in java.time, but you can acheive the same result by using myZonedDateTime.isAfter(ZonedDateTime.now()) or myOffsetDateTime.isAfter(OffsetDateTime.now()).
+    This method is not available in java.time, but you can achieve the same result by using myZonedDateTime.isAfter(ZonedDateTime.now()) or myOffsetDateTime.isAfter(OffsetDateTime.now()).
 
     This recipe is designed to match on broken code as part of an overall Joda-Time to java.time migration. The method that is being searched for does not actually exist on ZoneDateTime/OffsetDateTime.
     After migrating a DateTime instance to a ZoneDateTime or OffsetDateTime, subsequent calls may be made to methods that existed for DateTime, but no longer exist for ZonedDateTime/OffsetDateTime.

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-isBeforeNow.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-isBeforeNow.yaml
@@ -8,7 +8,7 @@ metadata:
   enabled: true
   comment: |
     Joda-Time's DateTime class provided an isBeforeNow method to conveniently check if the datetime is before the current Instant in time.
-    This method is not available in java.time, but you can acheive the same result by using myZonedDateTime.isBefore(ZonedDateTime.now()) or myOffsetDateTime.isBefore(OffsetDateTime.now()).
+    This method is not available in java.time, but you can achieve the same result by using myZonedDateTime.isBefore(ZonedDateTime.now()) or myOffsetDateTime.isBefore(OffsetDateTime.now()).
 
     This recipe is designed to match on broken code as part of an overall Joda-Time to java.time migration. The method that is being searched for does not actually exist on ZoneDateTime/OffsetDateTime.
     After migrating a DateTime instance to a ZoneDateTime or OffsetDateTime, subsequent calls may be made to methods that existed for DateTime, but no longer exist for ZonedDateTime/OffsetDateTime.

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-minus-long.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-minus-long.yaml
@@ -1,14 +1,14 @@
 id: scw:java.time:Joda-Time:DateTime-minus-long
 version: 10
 metadata:
-  name: Rewrite minus(long) method call to java.time equivalent
-  shortDescription: Rewrite minus(long) method call to java.time equivalent
+  name: Rewrite minus millis method call to java.time equivalent
+  shortDescription: Rewrite minus millis method call to java.time equivalent
   level: warning
   language: java
   enabled: true
   comment: |
-    Joda-Time's DateTime class provided a minus(long) method to create a new DateTime object by subtracting milliseconds from an existing DateTime object.
-    This method is not available in java.time, but you can acheive the same result by using minus(long, ChronoUnit.MILLIS)
+    Joda-Time's DateTime class provided methods to create a new DateTime object by subtracting milliseconds from an existing DateTime object.
+    These methods are not available in java.time, but you can achieve the same result by using minus(long, ChronoUnit.MILLIS)
 
     This recipe is designed to match on broken code as part of an overall Joda-Time to java.time migration. The method that is being searched for does not actually exist on ZoneDateTime/OffsetDateTime.
     After migrating a DateTime instance to a ZoneDateTime or OffsetDateTime, subsequent calls may be made to methods that existed for DateTime, but no longer exist for ZonedDateTime/OffsetDateTime.
@@ -24,13 +24,16 @@ search:
         - type: java.lang.Long
         - type: int
         - type: java.lang.Integer
+    allOf:
+    - anyOf:
+      - name: minus
+      - name: minusMillis
+    - anyOf:
+      - type: java.time.ZonedDateTime
+      - type: java.time.OffsetDateTime
     argCount: 1
-    name: minus
-    anyOf:
-    - type: java.time.ZonedDateTime
-    - type: java.time.OffsetDateTime
 availableFixes:
-- name: 'Rewrite minus(long) to java.time equivalent: minus(value, ChronoUnit.MILLIS)'
+- name: 'Rewrite to java.time equivalent: minus(value, ChronoUnit.MILLIS)'
   actions:
   - rewrite:
       to: '{{{ qualifier }}}.minus({{{ arguments.0 }}}, java.time.temporal.ChronoUnit.MILLIS)'

--- a/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-plus-long.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/DateTime/DateTime-plus-long.yaml
@@ -1,14 +1,14 @@
 id: scw:java.time:Joda-Time:DateTime-plus-long
 version: 10
 metadata:
-  name: Rewrite DateTime plus(long) to java.time equivalent
-  shortDescription: Rewrite DateTime plus(long) to java.time equivalent
+  name: Rewrite plus millis to java.time equivalent
+  shortDescription: Rewrite plus millis to java.time equivalent
   level: warning
   language: java
   enabled: true
   comment: |
-    Joda-Time's DateTime class provided a plus(long) method to create a new DateTime object by adding milliseconds to an existing DateTime object.
-    This method is not available in java.time, but you can acheive the same result by using plus(long, ChronoUnit.MILLIS)
+    Joda-Time's DateTime class provided methods to create a new DateTime object by adding milliseconds to an existing DateTime object.
+    These methods are not available in java.time, but you can achieve the same result by using plus(long, ChronoUnit.MILLIS)
 
     This recipe is designed to match on broken code as part of an overall Joda-Time to java.time migration. The method that is being searched for does not actually exist on ZoneDateTime/OffsetDateTime.
     After migrating a DateTime instance to a ZoneDateTime or OffsetDateTime, subsequent calls may be made to methods that existed for DateTime, but no longer exist for ZonedDateTime/OffsetDateTime.
@@ -24,13 +24,16 @@ search:
         - type: java.lang.Long
         - type: int
         - type: java.lang.Integer
+    allOf:
+    - anyOf:
+      - name: plus
+      - name: plusMillis
+    - anyOf:
+      - type: java.time.ZonedDateTime
+      - type: java.time.OffsetDateTime
     argCount: 1
-    name: plus
-    anyOf:
-    - type: java.time.ZonedDateTime
-    - type: java.time.OffsetDateTime
 availableFixes:
-- name: 'Rewrite plus(long) to java.time equivalent: plus(value, ChronoUnit.MILLIS)'
+- name: 'Rewrite to java.time equivalent: plus(value, ChronoUnit.MILLIS)'
   actions:
   - rewrite:
       to: '{{{ qualifier }}}.plus({{{ arguments.0 }}}, java.time.temporal.ChronoUnit.MILLIS)'

--- a/recipes/Java/JodaTimeToJavaTime/cookbook.yaml
+++ b/recipes/Java/JodaTimeToJavaTime/cookbook.yaml
@@ -1,0 +1,2 @@
+id: f9184d36-193d-4337-a6d3-faef769372c1
+name: JodaTime Cookbook (for testing)


### PR DESCRIPTION
Instead of creating new recipes for minusMillis and plusMillis I have
updated the existing minus/plus recipes because the fix is the same.
I also noticed a misspelling of 'achieve' so I have updated this in the
isAfterNow and isBeforeNow recipes.
I have also included a cookbook.yaml file to be used when testing the
recipes, allowing you to add this directory to your sensei cookbooks
directly without the warning 'there is no cookbook.yaml'.

Closes SEN-2592