### PR TITLE
update recommended upgrade to 2.16.0

### DIFF
--- a/recipes/Java/Logging/Log4J/log4j_log4shell.yaml
+++ b/recipes/Java/Logging/Log4J/log4j_log4shell.yaml
@@ -15,14 +15,14 @@ scopes:
   library:
     name:
       contains: org.apache.logging.log4j:log4j-core
-    maxVersion: 2.14.999
+    maxVersion: 2.15.999
 availableFixes:
 - name: Read about Log4Shell vulnerability (CVE-2021-44228)
   actions:
   - goto:
       type: URL
       value: https://log4shell.com/
-- name: Upgrade to Log4j 2.15.0 or higher (edit pom.xml/build.gradle)
+- name: Upgrade to Log4j 2.16.0 or higher (edit pom.xml/build.gradle)
   actions:
   - goto:
       type: URL


### PR DESCRIPTION
- trigger on any version <= 2.15.999
- recommend upgrading to 2.16.0

For info on CVE-2021-45046 see https://lists.apache.org/thread/83y7dx5xvn3h5290q1twn16tltolv88f