### PR TITLE
Use org.testng.AssertJUnit instead of .internal.junit.ArrayAsserts

### DIFF
--- a/recipes/Java/AssertJ/From JUnit/JUnit_assertArrayEquals.yaml
+++ b/recipes/Java/AssertJ/From JUnit/JUnit_assertArrayEquals.yaml
@@ -14,7 +14,7 @@ search:
     anyOf:
     - type: org.junit.Assert
     - type: org.junit.jupiter.api.Assertions
-    - type: org.testng.internal.junit.ArrayAsserts
+    - type: org.testng.AssertJUnit
 availableFixes:
 - doStaticImports: true
   name: Change to assertThat(actualArray).isEqualTo(expectedArray)

--- a/recipes/Java/AssertJ/From JUnit/JUnit_assertArrayEquals_message.yaml
+++ b/recipes/Java/AssertJ/From JUnit/JUnit_assertArrayEquals_message.yaml
@@ -23,7 +23,7 @@ search:
     - args:
         1:
           type: String
-      type: org.testng.internal.junit.ArrayAsserts
+      type: org.testng.AssertJUnit
 availableFixes:
 - doStaticImports: true
   name: Change to assertThat(actualArray).as(message).isEqualTo(expectedArray)


### PR DESCRIPTION
This is just a follow-up to SEN-2564, now that the static method
matching behaviour has been updated so these recipes can use
org.testng.AssertJUnit instead.

**Note: this should not be merged until Sensei version 2022.1.2 has
been released**